### PR TITLE
Patrick... zzSniffy, RIP. You will be missed. 

### DIFF
--- a/Commands (Tools, Events, Methods, etc)/CM_Shortcuts.cs
+++ b/Commands (Tools, Events, Methods, etc)/CM_Shortcuts.cs
@@ -32,7 +32,7 @@ namespace GameEditorStudio
             {
                 if (Directory.Exists(project.ProjectInputDirectory))
                 {
-                    System.Diagnostics.Process.Start("explorer.exe", project.ProjectInputDirectory);
+                    LibraryMan.OpenFolder(project.ProjectInputDirectory);
                 }
                 else
                 {
@@ -73,7 +73,7 @@ namespace GameEditorStudio
 
                 if (Directory.Exists(project.ProjectOutputDirectory))
                 {
-                    System.Diagnostics.Process.Start("explorer.exe", project.ProjectOutputDirectory);
+                    LibraryMan.OpenFolder(project.ProjectOutputDirectory);
                 }
                 else
                 {
@@ -114,7 +114,7 @@ namespace GameEditorStudio
 
                 if (Directory.Exists(folderPath))
                 {
-                    System.Diagnostics.Process.Start("explorer.exe", folderPath);
+                    LibraryMan.OpenFolder(folderPath);
                 }
                 else
                 {
@@ -144,15 +144,15 @@ namespace GameEditorStudio
                 // Open the folder in the file explorer
                 if (Directory.Exists(folderPath))
                 {
-                    System.Windows.MessageBox.Show("We can't find where your downloads folder is! :(" +
-                        "\n" +
-                        "\nIDK what would cause this error. Maybe your on a max or linux PC instead of windows?" +
-                        "\nIf anyone gets this error on windows, please report it.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                    LibraryMan.OpenFolder(folderPath);
                 }
                 else
                 {
-                    System.Windows.MessageBox.Show("Crystal editor folder wasn't found. This should literally never happen, please report this :(" +
-                        "\n.", "Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                    LibraryMan.NotificationNegative("Error: Can't find downloads folder.",
+                        "We can't find where your downloads folder is! :( " +
+                        "IDK what would cause this error. Maybe your on mac or linux PC instead of windows? " +
+                        "If anyone gets this error on windows, please report it."
+                        );                    
                 }
             }
             catch
@@ -173,7 +173,7 @@ namespace GameEditorStudio
                 // Open the folder in the file explorer
                 if (Directory.Exists(folderPath))
                 {
-                    System.Diagnostics.Process.Start("explorer.exe", folderPath);
+                    LibraryMan.OpenFolder(folderPath);
                 }
                 else
                 {

--- a/Commands (Tools, Events, Methods, etc)/Tools.xaml
+++ b/Commands (Tools, Events, Methods, etc)/Tools.xaml
@@ -36,7 +36,7 @@
             <ContentControl MinHeight="150"  DockPanel.Dock="Top" Margin="0,10,0,15"  >
 
                 <DockPanel>
-                    <ScrollViewer Width="115" DockPanel.Dock="Left" VerticalScrollBarVisibility="Auto" >
+                    <ScrollViewer Width="120" DockPanel.Dock="Left" VerticalScrollBarVisibility="Auto" >
                         <DockPanel >
                             <Label Content="Tools" DockPanel.Dock="Top" HorizontalContentAlignment="Center" FontSize="20" Margin="0,-5,0,-5" FontWeight="Bold" FontFamily="Arial Black"/>
                             <DockPanel DockPanel.Dock="Top">

--- a/Databases/StandardEditorData.cs
+++ b/Databases/StandardEditorData.cs
@@ -5,6 +5,7 @@ using System.Security.Policy;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Controls;
+using System.Windows.Documents;
 
 namespace GameEditorStudio
 {
@@ -52,6 +53,7 @@ namespace GameEditorStudio
         // They are not saved to XML or reloaded 
 
         public Entry SelectedEntry { get; set; } //The entry the user is currently selecting. In DEV mode, This entry is highlighted.
+        public List<Entry>? EntryList { get; set; } = new(); //A master list to make it easy to make changes to all of them at once.
         public int TableRowIndex { get; set; } //Not XML, used to save data when changing items in a collection. It's equal to an ItemInfo's Index.        
         public DockPanel MainDockPanel { get; set; } //The right side's panel inside a scroll viewer.
     }
@@ -132,16 +134,22 @@ namespace GameEditorStudio
         public string ColumnName { get; set; } = "New Column"; //XML The name of a column.
         public DockPanel? ColumnGrid { get; set; }
         public List<Entry>? EntryList { get; set; } = new();
+
+        public List<CItem>? MasterList { get; set; } = new();
         public Label ColumnLabel { get; set; }
         public Category ColumnRow { get; set; }
+
+        //public List<T> Stuff { get; set; } = new(); //This is a list of stuff that the column holds. It can be used to hold any type of object, but is currently only used to hold Entry objects.
 
         public string Key { get; set; } = LibraryMan.GenerateKey(); //Unused, Only exists incase of future features. 
     }
 
-    public class Group //A way to group entries together, like a folder.
+    public abstract class CItem { }
+
+    public class Group : CItem //A way to group entries together, like a folder.
     {
         public string GroupName { get; set; } = "New Group"; //XML The name of a column.
-        public DockPanel? GroupGrid { get; set; }
+        public DockPanel? GroupPanel { get; set; }
         public List<Entry>? EntryList { get; set; } = new();
         public Label GroupLabel { get; set; }
         public Column GroupColumn { get; set; }
@@ -149,7 +157,7 @@ namespace GameEditorStudio
     }
     
 
-    public class Entry
+    public class Entry : CItem
     {
         public string Name { get; set; } = "";  //XML //The Name / Label an entry Gets. Later, it will default to "???"  
         public string Notepad { get; set; } = ""; //XML

--- a/Editors/Standard/GenerateStandardEditor.cs
+++ b/Editors/Standard/GenerateStandardEditor.cs
@@ -141,12 +141,7 @@ namespace GameEditorStudio
                 CreateCategory(EditorClass.StandardEditorData, CatClass, TheWorkshop, Database, -1);
 
                 foreach (Column ColumnClass in CatClass.ColumnList/*.ToList()*/)
-                {
-                    //if (ColumnClass.EntryList == null || ColumnClass.EntryList.Count == 0) //Delete column if it's empty. 
-                    //{
-                    //    CatClass.ColumnList.Remove(ColumnClass); 
-                    //    continue; 
-                    //}
+                {                   
 
                     CreateColumn(CatClass, ColumnClass, TheWorkshop, Database, -1);
 
@@ -622,7 +617,10 @@ namespace GameEditorStudio
 
         }
 
-
+        public void CreateGroup() 
+        {
+        
+        }
 
         public void CreateColumn(Category RowClass, Column ColumnClass, Workshop TheWorkshop, WorkshopData Database, int Index)
         {
@@ -897,6 +895,7 @@ namespace GameEditorStudio
             Border.CornerRadius = new CornerRadius(3);
             DockPanel.SetDock(Border, Dock.Top);
             Border.Margin = new Thickness(4, 0, 5, 3);// Left Top Right Bottom 
+            Border.MinHeight = 38; //Height of a entry, so it doesn't shrink too small when there are no entrys in it.
 
             if (Properties.Settings.Default.ShowHiddenEntrys == false && (EntryClass.IsEntryHidden == true || EntryClass.IsTextInUse == true))
             {
@@ -989,6 +988,17 @@ namespace GameEditorStudio
 
                 StandardEditorMethods standardEditorMethods = new StandardEditorMethods();
                 standardEditorMethods.MoveEntrysToColumn(ListOfEntrys, toColumn);
+            }
+
+            MenuItem EntryCreateNewGroup = new MenuItem();
+            EntryCreateNewGroup.Header = "  Create new group  ";
+            contextMenu.Items.Add(EntryCreateNewGroup);
+            EntryCreateNewGroup.Click += new RoutedEventHandler(NewColumnGroup);
+            void NewColumnGroup(object sender, RoutedEventArgs e)
+            {
+                StandardEditorMethods standardEditorMethods = new StandardEditorMethods();
+                standardEditorMethods.CreateNewGroup(EntryClass);
+                
             }
 
 

--- a/Editors/Standard/StandardEditorMethods.cs
+++ b/Editors/Standard/StandardEditorMethods.cs
@@ -3,13 +3,21 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Windows;
 using System.Windows.Controls;
 
 namespace GameEditorStudio
 {
     internal class StandardEditorMethods
     {
-                
+
+        public void CreateNewGroup(Entry EntryClass) 
+        {
+            Column EntryColumn = EntryClass.EntryColumn;
+
+
+        }
+
         public void MoveEntrysToEntry(List<Entry> EntrysListToMove, Entry EntryToMoveUnder)
         {
             if (EntrysListToMove.Contains(EntryToMoveUnder)) 
@@ -18,6 +26,8 @@ namespace GameEditorStudio
             }
 
             int i = 0;
+            Column BeforeColumn = EntrysListToMove[0].EntryColumn; //Save the column before we change it, so we can delete it later if needed.
+            Column AfterColumn = EntryToMoveUnder.EntryColumn; //Save the column after we change it, so we can delete it later if needed.
 
             foreach (Entry EntryToMove in EntrysListToMove) 
             {
@@ -37,10 +47,16 @@ namespace GameEditorStudio
 
 
             DeleteEmptyColumnsAndMakeNewOnes(EntryToMoveUnder.EntryEditor.StandardEditorData);
+            LabelWidth(BeforeColumn);
+            LabelWidth(AfterColumn);
+
         }
 
         public void MoveEntrysToColumn(List<Entry> EntrysListToMove, Column Column) 
         {
+            Column BeforeColumn = EntrysListToMove[0].EntryColumn; //Save the column before we change it, so we can delete it later if needed.
+            Column AfterColumn = Column; //Save the column after we change it, so we can delete it later if needed.
+
             foreach (Entry EntryToMove in EntrysListToMove)
             {
                 EntryToMove.EntryColumn.ColumnGrid.Children.Remove(EntryToMove.EntryBorder);
@@ -54,6 +70,8 @@ namespace GameEditorStudio
             }
 
             DeleteEmptyColumnsAndMakeNewOnes(Column.ColumnRow.SWData);
+            LabelWidth(BeforeColumn);
+            LabelWidth(AfterColumn);
         }
 
         public void EntryActivate(Workshop TheWorkshop, Entry EntryClass) 
@@ -115,7 +133,34 @@ namespace GameEditorStudio
         }
 
 
-        
+        public void LabelWidth(Column ColumnClass)
+        {
+
+
+            double maxWidth = 0;
+            var EntryList = ColumnClass.EntryList;
+
+            // Measure the desired width of each label without restrictions
+            foreach (Entry entry in EntryList)
+            {
+                entry.EntryLabel.MinWidth = 0;
+                entry.EntryLabel.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
+                double labelWidth = entry.EntryLabel.DesiredSize.Width;
+                if (labelWidth > maxWidth)
+                {
+                    maxWidth = labelWidth;
+                }
+            }
+
+            // Set the MinWidth of each label to the widest value
+            foreach (Entry entry in EntryList)
+            {
+                entry.EntryLabel.MinWidth = maxWidth;
+            }
+        }
+
+
+
 
 
     }

--- a/Game Editor Studio.csproj
+++ b/Game Editor Studio.csproj
@@ -10,6 +10,15 @@
     <UseWPF>true</UseWPF>
     <ApplicationIcon>Graphics\Game Editor Studio Icon.ico</ApplicationIcon>
     <StartupObject></StartupObject>
+	
+    <!-- Publish settings -->
+    <PublishSingleFile>true</PublishSingleFile>
+    <PublishTrimmed>false</PublishTrimmed> <!-- Leave off unless you're sure -->
+    <SelfContained>true</SelfContained>
+    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier> <!-- Or win-x86 if needed -->
+	<DebugType>none</DebugType>
+	<DebugSymbols>false</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Main/EntryManager.cs
+++ b/Main/EntryManager.cs
@@ -680,6 +680,7 @@ namespace GameEditorStudio
             int BitMinWidth = 33;
             var BitMargin = new Thickness(0, 0, 3, 0); // Left Top Right Bottom 
             var DockMargin = new Thickness(0, 3, 0, 3); // Left Top Right Bottom 
+
             ////////////////////////////////////////////////
             DockPanel BitFlag1 = new();
             DockPanel.SetDock(BitFlag1, Dock.Top);

--- a/User Controls/FileManager.xaml
+++ b/User Controls/FileManager.xaml
@@ -42,7 +42,7 @@
                         <RowDefinition Height="*"/>
                     </Grid.RowDefinitions>
                     <Label Content="Location" Grid.Row="0" Grid.Column="0"/>
-                    <TextBox x:Name="FileLocationTextbox" Grid.Row="0" Grid.Column="1" Width="Auto" Margin="3" />
+                    <TextBox x:Name="FileLocationTextbox" Grid.Row="0" Grid.Column="1" Width="Auto" Margin="3" TextChanged="FileLocationTextboxTextChanged"/>
 
                     <Label Content="File Note" Grid.Row="1" Grid.Column="0"/>
                     <TextBox x:Name="FileNoteBox" Grid.Row="1" Grid.Column="1" Margin="3" TextChanged="FileNoteBoxTextChanged"  />

--- a/User Controls/FileManager.xaml.cs
+++ b/User Controls/FileManager.xaml.cs
@@ -398,5 +398,18 @@ namespace GameEditorStudio
             }
             
         }
+
+        private void FileLocationTextboxTextChanged(object sender, TextChangedEventArgs e)
+        {
+            FileLocationTextbox.ToolTip = "" +
+                "Location: " +
+                "\n" + FileLocationTextbox.Text +
+                "\n\n" +
+                "From Project Input: " +
+                "\n" + TheWorkshop.ProjectDataItem.ProjectInputDirectory + "\\"+ FileLocationTextbox.Text  +
+                "\n\n" +
+                "From Project Output: " +
+                "\n" + TheWorkshop.ProjectDataItem.ProjectOutputDirectory + "\\"+ FileLocationTextbox.Text; // Update the tooltip to show the file location text
+        }
     }
 }

--- a/User Controls/TextSourceManager.xaml
+++ b/User Controls/TextSourceManager.xaml
@@ -252,7 +252,7 @@
                         <TabItem Header="Link to Editor" Name="Tab3" Tag="Editor">
                             <!--List to Editor-->
                             <Grid x:Name="GridListFromEditor" Background="#FF22561B" >
-                                <Border Margin="0,0,753,0">
+                                <Border HorizontalAlignment="Left" Width="343">
                                     <DockPanel>
                                         <DockPanel DockPanel.Dock="Top" Style="{DynamicResource HeaderDock}" LastChildFill="False" >
                                             <Label Content="Editors" FontWeight="Bold"/>
@@ -316,7 +316,7 @@
 
 
                                                 <TextBox x:Name="ItemsNumBox" MinWidth="30"  TextWrapping="Wrap" Text="0&#xA;1&#xA;2&#xA;3&#xA;4&#xA;5&#xA;6&#xA;7&#xA;8&#xA;9&#xA;10&#xA;11&#xA;12&#xA;13&#xA;14&#xA;15&#xA;16&#xA;17&#xA;18&#xA;19&#xA;20&#xA;21&#xA;22"  DockPanel.Dock="Left"  IsEnabled="False" FontSize="20" />
-                                                <TextBox x:Name="ItemsEditBox"  AcceptsReturn="False" Text="Iron Sword&#xD;&#xA;Potion&#xD;&#xA;Fireball"  DockPanel.Dock="Left" FontSize="20" TextChanged="NothingNameListTextboxTextChanged" PreviewKeyDown="NothingItemsEditBoxPreviewKeyDown"/>
+                                                <TextBox x:Name="ItemsEditBox"  AcceptsReturn="True" Text="Iron Sword&#xD;&#xA;Potion&#xD;&#xA;Fireball"  DockPanel.Dock="Left" FontSize="20" TextChanged="NothingNameListTextboxTextChanged" PreviewKeyDown="NothingItemsEditBoxPreviewKeyDown"/>
 
 
                                             </DockPanel>

--- a/User Controls/TextSourceManager.xaml.cs
+++ b/User Controls/TextSourceManager.xaml.cs
@@ -783,45 +783,45 @@ namespace GameEditorStudio
 
         private void NothingItemsEditBoxPreviewKeyDown(object sender, KeyEventArgs e) //more GPT code to stop the user from axidentally deleting lines in the Nothing Name Textbox.
         {
-            var tb = (TextBox)sender;
-            int lineCountBefore = tb.Text.Split(new[] { "\r\n", "\n", "\r" }, StringSplitOptions.None).Length;
+            //var tb = (TextBox)sender;
+            //int lineCountBefore = tb.Text.Split(new[] { "\r\n", "\n", "\r" }, StringSplitOptions.None).Length;
 
-            string newText = tb.Text;
-            int caret = tb.CaretIndex;
-            int selStart = tb.SelectionStart;
-            int selLength = tb.SelectionLength;
+            //string newText = tb.Text;
+            //int caret = tb.CaretIndex;
+            //int selStart = tb.SelectionStart;
+            //int selLength = tb.SelectionLength;
 
-            if (e.Key == Key.Back)
-            {
-                if (selLength > 0)
-                {
-                    newText = newText.Remove(selStart, selLength);
-                }
-                else if (caret > 0)
-                {
-                    newText = newText.Remove(caret - 1, 1);
-                }
-            }
-            else if (e.Key == Key.Delete)
-            {
-                if (selLength > 0)
-                {
-                    newText = newText.Remove(selStart, selLength);
-                }
-                else if (caret < newText.Length)
-                {
-                    newText = newText.Remove(caret, 1);
-                }
-            }
-            else return; // Let other keys through
+            //if (e.Key == Key.Back)
+            //{
+            //    if (selLength > 0)
+            //    {
+            //        newText = newText.Remove(selStart, selLength);
+            //    }
+            //    else if (caret > 0)
+            //    {
+            //        newText = newText.Remove(caret - 1, 1);
+            //    }
+            //}
+            //else if (e.Key == Key.Delete)
+            //{
+            //    if (selLength > 0)
+            //    {
+            //        newText = newText.Remove(selStart, selLength);
+            //    }
+            //    else if (caret < newText.Length)
+            //    {
+            //        newText = newText.Remove(caret, 1);
+            //    }
+            //}
+            //else return; // Let other keys through
 
-            int lineCountAfter = newText.Split(new[] { "\r\n", "\n", "\r" }, StringSplitOptions.None).Length;
+            //int lineCountAfter = newText.Split(new[] { "\r\n", "\n", "\r" }, StringSplitOptions.None).Length;
 
 
-            if (lineCountAfter != lineCountBefore)
-            {                
-                e.Handled = true; // Block if line count decreased
-            }
+            //if (lineCountAfter != lineCountBefore)
+            //{                
+            //    e.Handled = true; // Block if line count decreased
+            //}
         }
 
     }

--- a/User Controls/TheLeftBar.xaml.cs
+++ b/User Controls/TheLeftBar.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -502,6 +503,7 @@ namespace GameEditorStudio
 
         private async void ItemsTreeSelectedItemChanged(object sender, RoutedPropertyChangedEventArgs<object> e) //When the selected item is changed, we save the current item entry info, and load the new items info.
         {
+            Stopwatch stopwatch = Stopwatch.StartNew();
             //I disable selection effects sometimes when modifying items in the collection while it is open.
             if (TheWorkshop.TreeViewSelectionEnabled)
             {
@@ -578,6 +580,9 @@ namespace GameEditorStudio
 
 
             } //End of If selection is enabled.
+
+            stopwatch.Stop();
+            Debug.WriteLine($"[Timer] Item Select took {stopwatch.ElapsedMilliseconds} ms");
         }
 
 

--- a/Windows/GameLibrary.xaml
+++ b/Windows/GameLibrary.xaml
@@ -127,6 +127,8 @@
                             <ContextMenu>
                                 <MenuItem Header="New Project" Click="CreateNewProject" />
                                 <MenuItem Header="Delete Project" Click="DeleteProject" />
+                                <MenuItem Header="Open Input Folder" Click="OpenInput" />
+                                <MenuItem Header="Open Output Folder" Click="OpenOutput" />
                             </ContextMenu>
                         </DataGrid.ContextMenu>
                     </DataGrid>

--- a/Windows/GameLibrary.xaml.cs
+++ b/Windows/GameLibrary.xaml.cs
@@ -13,6 +13,7 @@ using System.Runtime.CompilerServices;
 using System.Security.AccessControl;
 //using System.Reflection.Emit;
 using System.Security.Cryptography.X509Certificates;
+using System.Security.Policy;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
@@ -52,12 +53,23 @@ namespace GameEditorStudio
 
     //disabled a method in setup text editor
 
-
+    //OLD PUBLISH METHOD
     //1 open command prompt
-    //2 navigate to the .csproj file folder   M:    cd X
+    //2 navigate to the .csproj file folder  FOR EXAMPLE:  cd D:\Crystal Studio
     //3 copy paste this and hit enter
-    //dotnet publish -c Release -r win-x64 -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true    
+    //dotnet publish -c Release -r win-x64 -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true 
 
+    //NEW ONE
+    //now i have, in Game Editor Studio.csproj, if you open it in notepad, there are these lines that publish in mostly one file. From there, just take the exe and ignore the rest. No more command prompt, hell yes!
+    //<!-- Publish settings -->
+    //<PublishSingleFile>true</PublishSingleFile>
+    //<PublishTrimmed>false</PublishTrimmed> <!-- Leave off unless you're sure -->
+    //<SelfContained>true</SelfContained>
+    //<IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
+    //<RuntimeIdentifier>win-x64</RuntimeIdentifier> <!-- Or win-x86 if needed -->
+    //<DebugType>none</DebugType>
+    //<DebugSymbols>false</DebugSymbols>
+    //These last two debug lines, remove the Game Editor Studio.pdb from publishing, which is a debugging file. Hopefully unnecessary for release versions.
 
     public partial class GameLibrary : Window
     {        
@@ -90,12 +102,16 @@ namespace GameEditorStudio
 
             #if DEBUG //The App Location is the folder location of the executable. It's used by other parts of the program to find files.
             //I don't understand (and don't feel like spending the time) setting it up so release is the same as debug mode, so this is a temporary lazy fix.
-            LibraryMan.ApplicationLocation = Path.GetFullPath(Path.Combine(basepath, @"..\..\..\..\Release"));
+            LibraryMan.ApplicationLocation = Path.GetFullPath(Path.Combine(basepath, @"..\..\..\..\..\Release"));
             #else
             //ExePath = basepath; //for published versions of the program to the public.
             LibraryMan.ApplicationLocation = basepath;
             //LibraryMan.ApplicationLocation = Path.GetFullPath(Path.Combine(basepath, @"..\..\..\..\Release"));
+
+            //LibraryMan.ApplicationLocation = "D:\\Game Editor Studio\\Release";            
             #endif
+
+            //string test = LibraryMan.ApplicationLocation;
 
             ImportFromGoogle TableImport = new(); //Must happen before Setup Commands, because commands use tools.
             TableImport.ImportTableFromGoogle(this);   //Imports tools, commands, and common events.

--- a/Windows/Workshop.xaml
+++ b/Windows/Workshop.xaml
@@ -405,7 +405,7 @@
                                                 <Border DockPanel.Dock="Top">
                                                     <TabControl Name="EntryElementProperties" DockPanel.Dock="Top">
                                                         <TabItem Header="NumberBox" Name="EntryTab1">
-                                                            <DockPanel Height="149">
+                                                            <DockPanel >
                                                                 <DockPanel Style="{DynamicResource HeaderDock}" DockPanel.Dock="Top"  >
                                                                     <Label Content="Numberbox Properties" FontWeight="Bold" />
                                                                 </DockPanel>
@@ -416,7 +416,7 @@
                                                                             <ScaleTransform ScaleX="2" ScaleY="2" />
                                                                         </CheckBox.LayoutTransform>
                                                                     </CheckBox>
-                                                                    <Label Content="(This is what lets a game use negative&#xD;&#xA;numbers, but the details are complicated.&#xD;&#xA;Mouse hover the checkbox for a long tooltip)" HorizontalAlignment="Left" Margin="0,31,0,0" VerticalAlignment="Top"/>
+                                                                    <Label Content="(This is complicated, hover for tooltip)" HorizontalAlignment="Left" Margin="0,31,0,0" VerticalAlignment="Top"/>
                                                                 </Grid>
                                                             </DockPanel>
                                                         </TabItem>
@@ -427,10 +427,10 @@
                                                                 </DockPanel>
                                                                 <Grid>
                                                                     <Label Content="Checked Value" HorizontalAlignment="Left"  VerticalAlignment="Top" Margin="9,8,0,0"/>
-                                                                    <TextBox x:Name="PropertiesEntryCheckText" HorizontalAlignment="Left" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="100" Margin="186,10,0,0" IsEnabled="False"/>
+                                                                    <TextBox x:Name="PropertiesEntryCheckText" HorizontalAlignment="Left" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="100" Margin="172,10,0,0" IsEnabled="False"/>
                                                                     <Label Content="Unchecked Value" HorizontalAlignment="Left" Margin="10,38,0,0" VerticalAlignment="Top"/>
-                                                                    <TextBox x:Name="PropertiesEntryUncheckText" HorizontalAlignment="Left"  TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="100" Margin="186,41,0,0" IsEnabled="False"/>
-                                                                    <Label Content="I'll add this post-release, &#xD;&#xA;For now values are always 1 &amp; 0 ^^;" HorizontalAlignment="Left" Margin="10,69,0,0" VerticalAlignment="Top"/>
+                                                                    <TextBox x:Name="PropertiesEntryUncheckText" HorizontalAlignment="Left"  TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="100" Margin="172,41,0,0" IsEnabled="False"/>
+                                                                    <Label Content="Adding later, &#xA;for now its &#xD;&#xA;always 1 &amp; 0" HorizontalAlignment="Left" Margin="278,-8,0,0" VerticalAlignment="Top"/>
 
                                                                 </Grid>
                                                             </DockPanel>
@@ -438,7 +438,7 @@
                                                         <TabItem Header="BitFlag" Name="EntryTab3">
                                                             <DockPanel>
                                                                 <DockPanel Style="{DynamicResource HeaderDock}" DockPanel.Dock="Top"  >
-                                                                    <Label Content="Bitflag Properties     (Names / Checked / Unchecked)" FontWeight="Bold" />
+                                                                    <Label Content="Bitflag Properties (Names)" FontWeight="Bold" />
                                                                 </DockPanel>
                                                                 <Grid Margin="0,3,0,7">
 
@@ -460,18 +460,16 @@
                                                                     <Label Content="Menu Properties" FontWeight="Bold" />
                                                                 </DockPanel>
                                                                 <Grid >
-                                                                    <Label Content="Menu Type" HorizontalAlignment="Left" Margin="15,9,0,0" VerticalAlignment="Top"/>
-                                                                    <ComboBox x:Name="DropdownMenuType" HorizontalAlignment="Left" Margin="189,10,0,0" VerticalAlignment="Top"  DropDownClosed="PropertiesMenuType_DropDownClosed" Width="128">
+                                                                    <Label Content="Menu Type" HorizontalAlignment="Left" Margin="9,1,0,0" VerticalAlignment="Top"/>
+                                                                    <ComboBox x:Name="DropdownMenuType" HorizontalAlignment="Left" Margin="135,6,0,0" VerticalAlignment="Top"  DropDownClosed="PropertiesMenuType_DropDownClosed" Width="128">
                                                                         <ComboBoxItem Content="Dropdown" Name="MenuTypeItemDropdown"/>
                                                                         <ComboBoxItem Content="List" IsSelected="True" Name="MenuTypeItemList"/>
                                                                     </ComboBox>
-                                                                    <Label Content="Linked to:" HorizontalAlignment="Left" Margin="15,37,0,0" VerticalAlignment="Top" />
-                                                                    <Label Content="Nothing" HorizontalAlignment="Left" Margin="186,35,0,0" VerticalAlignment="Top" />
 
-                                                                    <Button Name="ButtonMenuManager" Content="Menu Manager" HorizontalAlignment="Left" Margin="15,69,0,0" VerticalAlignment="Top" Click="DoThing2" Width="150" Height="30" />
+                                                                    <Button Name="ButtonMenuManager" Content="Menu Manager" HorizontalAlignment="Left" Margin="10,40,0,0" VerticalAlignment="Top" Click="DoThing2" Width="253" Height="30" />
 
 
-                                                                    <Label Content="In the future, Editor linking will &#xD;&#xA;also support name notes. :D" HorizontalAlignment="Left" Margin="10,93,0,0" VerticalAlignment="Top"/>
+                                                                    <Label Content="Editor link will &#xA;later support &#xD;&#xA;name notes :D" HorizontalAlignment="Left" Margin="263,-6,0,0" VerticalAlignment="Top"/>
 
                                                                 </Grid>
                                                             </DockPanel>

--- a/Windows/Workshop.xaml.cs
+++ b/Windows/Workshop.xaml.cs
@@ -2560,12 +2560,12 @@ namespace GameEditorStudio
 
         private void OpenWorkshopInputButton(object sender, RoutedEventArgs e)
         {            
-            LibraryMan.OpenFolder(this.ProjectDataItem.ProjectInputDirectory);
+            LibraryMan.OpenFileFolder(PropertiesEditorReadGameDataFrom.Text);
         }
 
         private void OpenWorkshopOutputButton(object sender, RoutedEventArgs e)
         {            
-            LibraryMan.OpenFolder(this.ProjectDataItem.ProjectOutputDirectory);
+            LibraryMan.OpenFileFolder(EditorOutputLocationTextbox.Text);
         }
 
         private void OpenIconManager(object sender, RoutedEventArgs e)


### PR DESCRIPTION
- Changed from the old command prompt method to publish in a single file, to edits the .csproj file so that it publishes only 3 files by default, then i take only the exe and it works. No more command prompt! Although 3 files remain...

- further changed the publish, now only 2 files. the exe, and the last file is the windows settings i use. Once i remove using windows settings from my app, we will be publishing only the exe.

- Fixed weird crashes on release build.

- Right clicking a projects can now open project input and output folders.

- Fixed the link to editor editor list resizing with window size (it should not be doing that!)

- Cleaned up the menu properties panel to look better.
- Also clearned up every entry type's panel to be more compact.

- File Location textbox now tooltips the entire location, as well as from project input, and from project output!

- Entrys now have a minimum height so spreadsheet style format (by hiding entry names) looks better.

- Through some very jank code, entrys now properly resize the width of the column they were in before moving, and after moving.

- Created some group code, but groups are still not actually supported yet.

- The open buttosn for data table input output, now actually open to the file's actual folder rather then project input/output folder, and it even select the file in the browser so its easy to see.