### PR TITLE
The update that made tooltips easy and fun to use. 

### DIFF
--- a/Databases/StandardEditorData.cs
+++ b/Databases/StandardEditorData.cs
@@ -53,7 +53,7 @@ namespace GameEditorStudio
         // They are not saved to XML or reloaded 
 
         public Entry SelectedEntry { get; set; } //The entry the user is currently selecting. In DEV mode, This entry is highlighted.
-        public List<Entry>? EntryList { get; set; } = new(); //A master list to make it easy to make changes to all of them at once.
+        public List<Entry>? MasterEntryList { get; set; } = new(); //A master list to make it easy to make changes to all of them at once.
         public int TableRowIndex { get; set; } //Not XML, used to save data when changing items in a collection. It's equal to an ItemInfo's Index.        
         public DockPanel MainDockPanel { get; set; } //The right side's panel inside a scroll viewer.
     }
@@ -192,7 +192,15 @@ namespace GameEditorStudio
         public DockPanel? EntryDockPanel { get; set; } //The entrys Grid, visable to the used, and contains lots of information.
         public Label Symbology { get; set; }
         public Label EntryPrefix { get; set; }   //Used to show the byte offset to a user. Useful when creating an editor, and you don't know what things do yet.
-        public Label? EntryLabel { get; set; } //The name of an entry, appears on it's grid.
+        //public Label? EntryLabel { get; set; } //The name of an entry, appears on it's grid.
+        
+        /////////////////////The label
+        public Grid EntryLeftGrid { get; set; } = new ();
+        public Border UnderlineBorder { get; set; } = new();
+        public TextBlock EntryNameTextBlock { get; set; } = new(); //The textblock that shows the entry's name.
+        public Run RunEntryName { get; set; } = new(); //The run that shows the entry's name. This is used to change the color of the text, and to make it bold.
+        
+
 
         public Editor EntryEditor { get; set; }
         public Category EntryRow { get; set; }

--- a/Editors/Standard/GenerateStandardEditor.cs
+++ b/Editors/Standard/GenerateStandardEditor.cs
@@ -147,9 +147,9 @@ namespace GameEditorStudio
 
                     foreach (Entry EntryClass in ColumnClass.EntryList)
                     {
-                        CreateEntry(EditorClass, CatClass, ColumnClass, EntryClass, TheWorkshop, Database);
+                        CreateEntry(EditorClass, CatClass, ColumnClass, EntryClass, TheWorkshop, Database);                        
                     }
-                    TheWorkshop.LabelWidth(ColumnClass);
+                    StandardEditorMethods.LabelWidth(ColumnClass);
 
                 }
             }
@@ -160,7 +160,6 @@ namespace GameEditorStudio
             EManager.EntryBecomeActive(EditorClass.StandardEditorData.SelectedEntry);  //EditorClass.StandardEditorData.CategoryList[0].ColumnList[0].EntryList[0]
             EManager.UpdateEntryProperties(TheWorkshop, EditorClass);
 
-            StandardEditorMethods StandardEditorMethods = new();
             StandardEditorMethods.DeleteEmptyColumnsAndMakeNewOnes(EditorClass.StandardEditorData);
 
         }
@@ -463,11 +462,10 @@ namespace GameEditorStudio
             RowPanel.Style = (Style)Application.Current.Resources["RowStyle"];
             DockPanel.SetDock(RowPanel, Dock.Top);
             RowPanel.VerticalAlignment = VerticalAlignment.Stretch; //Top Bottom
-            RowPanel.HorizontalAlignment = HorizontalAlignment.Stretch; //Left Right            
+            RowPanel.HorizontalAlignment = HorizontalAlignment.Stretch; //Left Right    
 
             //RowPanel.Margin = new Thickness(18, 10, 18, 10); // Left Top Right Bottom 
-
-            //RowPanel.Margin = new Thickness(0, 5, 5, 0);
+            
             //if (Index == -1) { SWData.MainDockPanel.Children.Add(RowPanel); }
             //else { SWData.MainDockPanel.Children.Insert(Index, RowPanel); }
             CatBorder.Child = RowPanel;
@@ -636,7 +634,7 @@ namespace GameEditorStudio
             ColumnGrid.LastChildFill = false;
             //ColumnGrid.HorizontalAlignment = HorizontalAlignment.Left; //Left Right
             DockPanel.SetDock(ColumnGrid, Dock.Left);
-            ColumnGrid.Margin = new Thickness(0, 5, 0, 1); // Left Top Right Bottom 
+            ColumnGrid.Margin = new Thickness(2, 10, 0, 5); // Left Top Right Bottom  //(0, 5, 0, 1)
             ColumnGrid.MinHeight = 50; //Minimum height of a column, so it doesn't shrink too small when there are no entrys in it.
 
 
@@ -860,21 +858,20 @@ namespace GameEditorStudio
             //This makes an entry drop down at the bottom of a column. 
             void DropEntryOnColumnBody(object sender, DragEventArgs e)
             {
-                StandardEditorMethods standardEditorMethods = new StandardEditorMethods();
 
                 if (e.Data.GetDataPresent("EntryMoveList"))
                 {
 
                     List<Entry> EntryMoveList = (List<Entry>)e.Data.GetData("EntryMoveList");
 
-                    
-                    standardEditorMethods.MoveEntrysToColumn(EntryMoveList, ColumnClass);
+
+                    StandardEditorMethods.MoveEntrysToColumn(EntryMoveList, ColumnClass);
                 }
 
                 e.Handled = true; // 🛑 Prevent the entry's parent from stealing the drop.
 
-                
-                standardEditorMethods.EntryActivate(TheWorkshop, TheWorkshop.EntryClass); //this prevents a crash when immedietly merging the moved entry into a 2 byte.
+
+                StandardEditorMethods.EntryActivate(TheWorkshop, TheWorkshop.EntryClass); //this prevents a crash when immedietly merging the moved entry into a 2 byte.
             }
 
         }
@@ -962,8 +959,7 @@ namespace GameEditorStudio
                 int index = EntryClass.EntryColumn.ColumnRow.ColumnList.IndexOf(EntryClass.EntryColumn);
                 Column toColumn = EntryClass.EntryColumn.ColumnRow.ColumnList[index - 1];
 
-                StandardEditorMethods standardEditorMethods = new StandardEditorMethods();
-                standardEditorMethods.MoveEntrysToColumn(ListOfEntrys, toColumn);
+                StandardEditorMethods.MoveEntrysToColumn(ListOfEntrys, toColumn);
             }
 
 
@@ -986,8 +982,7 @@ namespace GameEditorStudio
                 int index = EntryClass.EntryColumn.ColumnRow.ColumnList.IndexOf(EntryClass.EntryColumn);
                 Column toColumn = EntryClass.EntryColumn.ColumnRow.ColumnList[index + 1];
 
-                StandardEditorMethods standardEditorMethods = new StandardEditorMethods();
-                standardEditorMethods.MoveEntrysToColumn(ListOfEntrys, toColumn);
+                StandardEditorMethods.MoveEntrysToColumn(ListOfEntrys, toColumn);
             }
 
             MenuItem EntryCreateNewGroup = new MenuItem();
@@ -996,8 +991,7 @@ namespace GameEditorStudio
             EntryCreateNewGroup.Click += new RoutedEventHandler(NewColumnGroup);
             void NewColumnGroup(object sender, RoutedEventArgs e)
             {
-                StandardEditorMethods standardEditorMethods = new StandardEditorMethods();
-                standardEditorMethods.CreateNewGroup(EntryClass);
+                StandardEditorMethods.CreateNewGroup(EntryClass);
                 
             }
 
@@ -1014,9 +1008,8 @@ namespace GameEditorStudio
                     
                 }
                 else
-                {                    
-                    StandardEditorMethods standardEditorMethods = new StandardEditorMethods();
-                    standardEditorMethods.EntryActivate(TheWorkshop, EntryClass);
+                {      
+                    StandardEditorMethods.EntryActivate(TheWorkshop, EntryClass);
                 }
 
                 
@@ -1135,8 +1128,7 @@ namespace GameEditorStudio
                 {
                     List<Entry> EntryMoveList = (List<Entry>)e.Data.GetData("EntryMoveList");
 
-                    StandardEditorMethods standardEditorMethods = new StandardEditorMethods();
-                    standardEditorMethods.MoveEntrysToEntry(EntryMoveList, EntryClass);
+                    StandardEditorMethods.MoveEntrysToEntry(EntryMoveList, EntryClass);
 
                 }
 
@@ -1178,85 +1170,29 @@ namespace GameEditorStudio
             EntryDockPanel.Children.Add(PrefixEID);
             EntryClass.EntryPrefix = PrefixEID;
 
+            ///////////////////STARTING HERE IS STUFF FOR THE PAINFULLY OVER COMPLICATED SYSTEM WHERE AN ENTRY GETS UNDERLINED IF IT HAS A TOOLTIP.//////////////////////
+            Grid NewPanel = EntryClass.EntryLeftGrid;
+            NewPanel.Background = Brushes.Transparent;
+            EntryDockPanel.Children.Add(NewPanel);
+            NewPanel.Children.Add(EntryClass.EntryNameTextBlock);
+            NewPanel.Children.Add(EntryClass.UnderlineBorder);  
+            EntryClass.UnderlineBorder.BorderBrush = (Brush)new BrushConverter().ConvertFrom("#A0A0A0");
+            EntryClass.UnderlineBorder.Margin = new Thickness(4, 0, 0, 4); // Left Top Right Bottom
+            EntryClass.UnderlineBorder.HorizontalAlignment = HorizontalAlignment.Left;
+            EntryClass.EntryNameTextBlock.Inlines.Add(EntryClass.RunEntryName);
 
-            //add a option to properties where a entrys can have a Icon on the left side. for easy, universal, user styling / expression.
-            Label NameBox = new Label();
-            //NameBox.Background = Brushes.IndianRed;
-            //NameBox.Height = 30;
-            NameBox.MinWidth = 80;
-            NameBox.FontSize = 20;
-            NameBox.HorizontalAlignment = HorizontalAlignment.Left;
-            NameBox.VerticalContentAlignment = VerticalAlignment.Center;
-            EntryDockPanel.Children.Add(NameBox);
-            if (EntryClass.IsNameHidden == false) { NameBox.Visibility = Visibility.Visible; }
-            if (EntryClass.IsNameHidden == true) { NameBox.Visibility = Visibility.Collapsed; }
-            EntryClass.EntryLabel = NameBox;
-                        
+            TextBlock EntryTextBlock = EntryClass.EntryNameTextBlock;
+            EntryTextBlock.Margin = new Thickness(4, 0, 2, 0);
+            EntryTextBlock.FontSize = 20;
+            EntryTextBlock.HorizontalAlignment = HorizontalAlignment.Left;
+            EntryTextBlock.VerticalAlignment = VerticalAlignment.Center;
 
-            if (EntryClass.Name == "")
-            {
-                NameBox.Content = "??? " + EntryClass.RowOffset;
-            }
-            if (EntryClass.Name != "")
-            {
-                NameBox.Content = NameBox.Content = EntryClass.Name;// "Entry X";
-            }
+            ToolTipService.SetInitialShowDelay(EntryClass.EntryLeftGrid, 200); // 0.3 seconds popup
+            ToolTipService.SetBetweenShowDelay(EntryClass.EntryLeftGrid, 0); // 0.1 seconds switch
 
+            ////////////////END OF UNDERLINE SYSTEM//////////////////////
 
-
-
-
-
-
-
-            //This last code auto-sets entrys to hidden if the entry's byte is also apart of a text table.
-            //I may want to change this to happen if its ANY known text table.
-            if (EditorClass.StandardEditorData.FileNameTable != null) //Happens when a table uses a user name list instead of from a game file.
-            {
-                if (EditorClass.StandardEditorData.FileNameTable.FileLocation != null)
-                {
-                    if (EditorClass.StandardEditorData.FileNameTable.FileLocation == EditorClass.StandardEditorData.FileDataTable.FileLocation)
-                    {
-                        int Min = EditorClass.StandardEditorData.DataTableStart;
-                        int Max = Min + EditorClass.StandardEditorData.DataTableRowSize;
-                        if (EditorClass.StandardEditorData.NameTableStart >= Min && EditorClass.StandardEditorData.NameTableStart <= Max)
-                        {
-                            int NAMEMIN = EditorClass.StandardEditorData.NameTableStart - EditorClass.StandardEditorData.DataTableStart;
-                            int NAMEMAX = NAMEMIN + EditorClass.StandardEditorData.NameTableTextSize - 1;//the 1st byte is "0", so we need a -1 for proper counting.
-                            if (EntryClass.RowOffset >= NAMEMIN && EntryClass.RowOffset <= NAMEMAX)
-                            {                                
-                                EntryClass.IsTextInUse = true;
-                                EntryClass.EntryLabel.Content = "Name";
-                            }
-                        }
-                    }
-                }
-            }
-
-
-            if (TheWorkshop.IsPreviewMode == false)
-            {
-                foreach (DescriptionTable ExtraTable in EditorClass.StandardEditorData.DescriptionTableList)
-                {
-                    if (EditorClass.StandardEditorData.FileDataTable.FileLocation == ExtraTable.FileTextTable.FileLocation)
-                    {
-                        int Min = EditorClass.StandardEditorData.DataTableStart;
-                        int Max = Min + EditorClass.StandardEditorData.DataTableRowSize;
-                        if (ExtraTable.Start >= Min && ExtraTable.Start <= Max)
-                        {
-                            int EXTRAMIN = ExtraTable.Start - EditorClass.StandardEditorData.DataTableStart;
-                            int EXTRAMAX = EXTRAMIN + ExtraTable.TextSize - 1;//the 1st byte is "0", so we need a -1 for proper counting.
-                            if (EntryClass.RowOffset >= EXTRAMIN && EntryClass.RowOffset <= EXTRAMAX)
-                            {                                
-                                EntryClass.IsTextInUse = true;                                
-                                EntryClass.EntryLabel.Content = "Text";
-                            }
-                        }
-                    }
-                }
-            }
-            
-            
+            StandardEditorMethods.UpdateEntryName(EntryClass);
 
 
 

--- a/Editors/Standard/LoadStandardEditor.cs
+++ b/Editors/Standard/LoadStandardEditor.cs
@@ -144,7 +144,8 @@ namespace GameEditorStudio
 
                 Entry EntryClass = new();
                 ColumnClass.EntryList.Add(EntryClass);
-                
+                EditorClass.StandardEditorData.MasterEntryList.Add(EntryClass); 
+
                 EntryClass.DataTableRowSize = Int32.Parse(Maker.TextBoxDataTableRowSize.Text);
                 EntryClass.RowOffset = i;
                 EntryClass.TableKey = EditorClass.StandardEditorData.TableKey;
@@ -319,6 +320,7 @@ namespace GameEditorStudio
                     {
 
                         Entry EntryClass = new();
+                        EditorClass.StandardEditorData.MasterEntryList.Add(EntryClass);
 
                         EntryClass.Name = Xentry.Element("Name")?.Value;
                         EntryClass.Notepad = Xentry.Element("Notepad")?.Value;

--- a/Main/EntryManager.cs
+++ b/Main/EntryManager.cs
@@ -486,7 +486,7 @@ namespace GameEditorStudio
 
         public void CreateNumberBox(Workshop TheWorkshop, Entry EntryClass)
         {
-            if (EntryClass.IsNameHidden == false) { EntryClass.EntryLabel.Visibility = Visibility.Visible; }
+            //if (EntryClass.IsNameHidden == false) { EntryClass.EntryNameTextBlock.Visibility = Visibility.Visible; }
             // Default properties if new
             if (EntryClass.EntryTypeNumberBox == null)
             {
@@ -614,7 +614,7 @@ namespace GameEditorStudio
 
         public void CreateCheckBox(Workshop TheWorkshop, Entry EntryClass)
         {
-            if (EntryClass.IsNameHidden == false) { EntryClass.EntryLabel.Visibility = Visibility.Visible; }
+            //if (EntryClass.IsNameHidden == false) { EntryClass.EntryNameTextBlock.Visibility = Visibility.Visible; }
 
             //Default properties if new
             if (EntryClass.EntryTypeCheckBox == null)
@@ -666,7 +666,7 @@ namespace GameEditorStudio
 
         public void CreateBitFlag(Workshop TheWorkshop, Entry EntryClass)
         {
-            EntryClass.EntryLabel.Visibility = Visibility.Collapsed;
+            EntryClass.EntryNameTextBlock.Visibility = Visibility.Collapsed;
 
             if (EntryClass.EntryTypeBitFlag == null)
             {
@@ -1099,7 +1099,7 @@ namespace GameEditorStudio
 
         public void CreateMenu(Entry EntryClass, Workshop TheWorkshop)
         {
-            if (EntryClass.IsNameHidden == false) { EntryClass.EntryLabel.Visibility = Visibility.Visible; }
+            if (EntryClass.IsNameHidden == false) { EntryClass.EntryNameTextBlock.Visibility = Visibility.Visible; }
             //Default properties if new
             if (EntryClass.EntryTypeMenu == null)
             {
@@ -1695,20 +1695,116 @@ namespace GameEditorStudio
         }
 
 
-        public void UpdateEntryProperties(Workshop TheWorkshop ,Editor EditorClass) //very similuar, but also happens when treeview item selection changes.
+        public void UpdateEntryProperties(Workshop TheWorkshop ,Editor EditorClass) 
         {
+            //This used to happen on tree view selection change, but it caused a shit ton of lag. Now it doesn't. if my program starts lagging again, consider if this is responsible! >:(
+
             if (TheWorkshop.IsPreviewMode == true) { return; }
+            LibraryMan.GotoGeneralEntry(TheWorkshop);
 
             Entry EntryClass = EditorClass.StandardEditorData.SelectedEntry;
-
-            
-
-            LibraryMan.GotoGeneralEntry(TheWorkshop);
-            TheWorkshop.PropertiesNameBox.Text = EntryClass.Name;
+            //////////////////////////////////////Workship Update//////////////////////////////////////////
             TheWorkshop.EditorClass = EntryClass.EntryEditor;
             TheWorkshop.CategoryClass = EntryClass.EntryRow;
             TheWorkshop.ColumnClass = EntryClass.EntryColumn;
             TheWorkshop.EntryClass = EntryClass;
+
+            //////////////////////////////////////Right Bar Settings Update//////////////////////////////////////////
+            TheWorkshop.PropertiesNameBox.Text = EntryClass.Name;   
+            
+            if (EntryClass.IsNameHidden == true) 
+            {
+                TheWorkshop.HideNameCheckbox.IsChecked = true;
+            }
+            else 
+            {
+                TheWorkshop.HideNameCheckbox.IsChecked = false;
+            }
+
+            if (EntryClass.IsEntryHidden == true)
+            {
+                TheWorkshop.HideEntryCheckbox.IsChecked = true;
+            }
+            else
+            {
+                TheWorkshop.HideEntryCheckbox.IsChecked = false;
+            }            
+
+            string FindEntryType = EntryClass.NewSubType.ToString();  //Entry Type Dropdown Menu.
+            foreach (ComboBoxItem item in TheWorkshop.PropertiesEntryType.Items)
+            {
+                if (item.Content.ToString() == FindEntryType)
+                {
+                    TheWorkshop.PropertiesEntryType.SelectedItem = item;
+                    break;
+                }
+            }
+
+
+            string FindEntryByteSize = "Dummy"; //Entry Size Dropdown Menu.
+            if (EntryClass.Endianness == "1") { FindEntryByteSize = "1 Byte"; } 
+            else if (EntryClass.Endianness == "2L") { FindEntryByteSize = "2 Bytes Little Endian"; }
+            else if (EntryClass.Endianness == "4L") { FindEntryByteSize = "4 Bytes Little Endian"; }
+            else if (EntryClass.Endianness == "2B") { FindEntryByteSize = "2 Bytes Big Endian"; }
+            else if (EntryClass.Endianness == "4B") { FindEntryByteSize = "4 Bytes Big Endian"; }
+            foreach (ComboBoxItem item in TheWorkshop.PropertiesEntryByteSizeComboBox.Items)
+            {
+                if (item.Content.ToString() == FindEntryByteSize)
+                {
+                    TheWorkshop.PropertiesEntryByteSizeComboBox.SelectedItem = item;
+                    break;
+                }
+            }
+
+
+            //////////////////////////////////////Right Bar Submenu Settings Update//////////////////////////////////////////
+            if (EntryClass.NewSubType == Entry.EntrySubTypes.NumberBox)
+            {                
+                if (EntryClass.EntryTypeNumberBox.NewNumberSign == EntryTypeNumberBox.TheNumberSigns.Unsigned) { TheWorkshop.NumberboxSignCheckbox.IsChecked = false; }
+                if (EntryClass.EntryTypeNumberBox.NewNumberSign == EntryTypeNumberBox.TheNumberSigns.Signed) { TheWorkshop.NumberboxSignCheckbox.IsChecked = true; }                
+            }
+
+            if (EntryClass.NewSubType == Entry.EntrySubTypes.CheckBox) 
+            {
+                TheWorkshop.PropertiesEntryCheckText.Text = EntryClass.EntryTypeCheckBox.TrueText;
+                TheWorkshop.PropertiesEntryUncheckText.Text = EntryClass.EntryTypeCheckBox.FalseText;
+            }
+
+            if (EntryClass.NewSubType == Entry.EntrySubTypes.BitFlag) 
+            {
+                TheWorkshop.PropertiesEntryBitFlag1Name.Text = EntryClass.EntryTypeBitFlag.BitFlag1Name;
+                TheWorkshop.PropertiesEntryBitFlag2Name.Text = EntryClass.EntryTypeBitFlag.BitFlag2Name;
+                TheWorkshop.PropertiesEntryBitFlag3Name.Text = EntryClass.EntryTypeBitFlag.BitFlag3Name;
+                TheWorkshop.PropertiesEntryBitFlag4Name.Text = EntryClass.EntryTypeBitFlag.BitFlag4Name; 
+                TheWorkshop.PropertiesEntryBitFlag5Name.Text = EntryClass.EntryTypeBitFlag.BitFlag5Name;
+                TheWorkshop.PropertiesEntryBitFlag6Name.Text = EntryClass.EntryTypeBitFlag.BitFlag6Name;
+                TheWorkshop.PropertiesEntryBitFlag7Name.Text = EntryClass.EntryTypeBitFlag.BitFlag7Name;
+                TheWorkshop.PropertiesEntryBitFlag8Name.Text = EntryClass.EntryTypeBitFlag.BitFlag8Name;
+            }
+
+
+            if (EntryClass.NewSubType == Entry.EntrySubTypes.Menu)
+            {
+                TheWorkshop.DropdownMenuType.IsEnabled = true;
+                if (EntryClass.EntryTypeMenu.MenuType == EntryTypeMenu.MenuTypes.Dropdown) { TheWorkshop.MenuTypeItemDropdown.IsSelected = true; }
+                else if (EntryClass.EntryTypeMenu.MenuType == EntryTypeMenu.MenuTypes.List) { TheWorkshop.MenuTypeItemList.IsSelected = true; }
+            }
+            else //failsafe
+            { 
+                TheWorkshop.DropdownMenuType.IsEnabled = false; 
+            }
+
+            //////////////////////////////////////Right Bar Hex Data Update//////////////////////////////////////////
+            UpdateEntryHexProperties(TheWorkshop, EditorClass);
+
+            //////////////////////////////////////END//////////////////////////////////////////
+            TheWorkshop.UpdateSymbology(EntryClass);
+
+        } //End of UpdateEntryProperties Method
+
+        public void UpdateEntryHexProperties(Workshop TheWorkshop, Editor EditorClass) 
+        {
+            Entry EntryClass = EditorClass.StandardEditorData.SelectedEntry;
 
             TheWorkshop.PropertiesEntryHexAddressTextbox.Text = (EditorClass.StandardEditorData.DataTableStart + (EditorClass.StandardEditorData.TableRowIndex * EntryClass.DataTableRowSize) + EntryClass.RowOffset).ToString("X2");
 
@@ -1716,13 +1812,14 @@ namespace GameEditorStudio
 
 
             /////////////////////Data Analyzer/////////////////////
-            TheWorkshop.PropertiesEntry1Byte.Text = EditorClass.StandardEditorData.FileDataTable.FileBytes[EditorClass.StandardEditorData.DataTableStart + (EditorClass.StandardEditorData.TableRowIndex * EntryClass.DataTableRowSize) + EntryClass.RowOffset].ToString("D");
+            //TheWorkshop.PropertiesEntry1Byte.Text = EditorClass.StandardEditorData.FileDataTable.FileBytes[EditorClass.StandardEditorData.DataTableStart + (EditorClass.StandardEditorData.TableRowIndex * EntryClass.DataTableRowSize) + EntryClass.RowOffset].ToString("D");
+            TheWorkshop.PropertiesEntry1Byte.Text = EntryClass.EntryByteDecimal;
             TheWorkshop.PropertiesEntryHex1Byte.Text = EditorClass.StandardEditorData.FileDataTable.FileBytes[EditorClass.StandardEditorData.DataTableStart + (EditorClass.StandardEditorData.TableRowIndex * EntryClass.DataTableRowSize) + EntryClass.RowOffset].ToString("X2");
 
-            TheWorkshop.PropertiesEntry1Byte.Text = EntryClass.EntryByteDecimal;
 
 
-            try 
+
+            try
             {
                 TheWorkshop.PropertiesEntry2ByteB.Text = BitConverter.ToUInt16(EditorClass.StandardEditorData.FileDataTable.FileBytes, EditorClass.StandardEditorData.DataTableStart + (EditorClass.StandardEditorData.TableRowIndex * EntryClass.DataTableRowSize) + EntryClass.RowOffset).ToString("D");
                 TheWorkshop.PropertiesEntryHex2ByteB.Text = BitConverter.ToUInt16(EditorClass.StandardEditorData.FileDataTable.FileBytes, EditorClass.StandardEditorData.DataTableStart + (EditorClass.StandardEditorData.TableRowIndex * EntryClass.DataTableRowSize) + EntryClass.RowOffset).ToString("X4");
@@ -1731,7 +1828,7 @@ namespace GameEditorStudio
                 ushort swappedValue2 = (ushort)IPAddress.HostToNetworkOrder((short)value2); // Swap the endianness
                 TheWorkshop.PropertiesEntry2ByteL.Text = swappedValue2.ToString("D"); // Convert the swapped value4 to a string using the desired format
                 TheWorkshop.PropertiesEntryHex2ByteL.Text = swappedValue2.ToString("X4"); // Convert the swapped value4 to a string using the desired format
-            } 
+            }
             catch
             {
                 TheWorkshop.PropertiesEntry2ByteB.Text = "END OF FILE";
@@ -1739,7 +1836,7 @@ namespace GameEditorStudio
                 TheWorkshop.PropertiesEntry2ByteL.Text = "END OF FILE";
                 TheWorkshop.PropertiesEntryHex2ByteL.Text = "END OF FILE";
             }
-            
+
             try
             {
                 TheWorkshop.PropertiesEntry4ByteB.Text = BitConverter.ToUInt32(EditorClass.StandardEditorData.FileDataTable.FileBytes, EditorClass.StandardEditorData.DataTableStart + (EditorClass.StandardEditorData.TableRowIndex * EntryClass.DataTableRowSize) + EntryClass.RowOffset).ToString("D");
@@ -1759,135 +1856,7 @@ namespace GameEditorStudio
                 TheWorkshop.PropertiesEntry4ByteL.Text = "END OF FILE";
                 TheWorkshop.PropertiesEntryHex4ByteL.Text = "END OF FILE";
             }
-
-
-
-            /////////////////////Checkboxes and Bitflags/////////////////////
-
-
-
-            //The Editor.SelectedEntry 
-
-
-
-
-
-
-
-            //////////////////////////////////////Entry Data / Various Dropdown Menus//////////////////////////////////////////
-
-
-            if (EntryClass.IsNameHidden == true) 
-            {
-                TheWorkshop.HideNameCheckbox.IsChecked = true;
-            }
-            else 
-            {
-                TheWorkshop.HideNameCheckbox.IsChecked = false;
-            }
-
-            if (EntryClass.IsEntryHidden == true)
-            {
-                TheWorkshop.HideEntryCheckbox.IsChecked = true;
-            }
-            else
-            {
-                TheWorkshop.HideEntryCheckbox.IsChecked = false;
-            }
-
-            //Entry.EntrySubTypes.NumberBox
-
-            string FindEntryType = EntryClass.NewSubType.ToString();  //Entry Type Dropdown Menu.
-            foreach (ComboBoxItem item in TheWorkshop.PropertiesEntryType.Items)
-            {
-                if (item.Content.ToString() == FindEntryType)
-                {
-                    TheWorkshop.PropertiesEntryType.SelectedItem = item;
-                    break;
-                }
-            }
-            //string FindEntryType = EntryClass.SubType;  //Entry Type Dropdown Menu.
-            //foreach (ComboBoxItem item in TheWorkshop.PropertiesEntryType.Items)
-            //{
-            //    if (item.Content.ToString() == FindEntryType)
-            //    {
-            //        TheWorkshop.PropertiesEntryType.SelectedItem = item;
-            //        break;
-            //    }
-            //}
-
-
-            string FindEntryByteSize = "Dummy"; //Entry Size Dropdown Menu.
-            if (EntryClass.Endianness == "1") { FindEntryByteSize = "1 Byte"; } 
-            else if (EntryClass.Endianness == "2L") { FindEntryByteSize = "2 Bytes Little Endian"; }
-            else if (EntryClass.Endianness == "4L") { FindEntryByteSize = "4 Bytes Little Endian"; }
-            else if (EntryClass.Endianness == "2B") { FindEntryByteSize = "2 Bytes Big Endian"; }
-            else if (EntryClass.Endianness == "4B") { FindEntryByteSize = "4 Bytes Big Endian"; }
-            foreach (ComboBoxItem item in TheWorkshop.PropertiesEntryByteSizeComboBox.Items)
-            {
-                if (item.Content.ToString() == FindEntryByteSize)
-                {
-                    TheWorkshop.PropertiesEntryByteSizeComboBox.SelectedItem = item;
-                    break;
-                }
-            }
-
-
-
-
-
-
-
-            //////////////////////////////////////Settings Per Entry Type//////////////////////////////////////////
-            TheWorkshop.DropdownMenuType.IsEnabled = false;  //failsafe
-
-
-            if (EntryClass.NewSubType == Entry.EntrySubTypes.NumberBox)
-            {
-                
-                if (EntryClass.EntryTypeNumberBox.NewNumberSign == EntryTypeNumberBox.TheNumberSigns.Unsigned) { TheWorkshop.NumberboxSignCheckbox.IsChecked = false; }
-                if (EntryClass.EntryTypeNumberBox.NewNumberSign == EntryTypeNumberBox.TheNumberSigns.Signed) { TheWorkshop.NumberboxSignCheckbox.IsChecked = true; }
-                
-            }
-
-
-
-
-            if (EntryClass.NewSubType == Entry.EntrySubTypes.CheckBox) 
-            {
-                TheWorkshop.PropertiesEntryCheckText.Text = EntryClass.EntryTypeCheckBox.TrueText;
-                TheWorkshop.PropertiesEntryUncheckText.Text = EntryClass.EntryTypeCheckBox.FalseText;
-
-            }
-
-
-            if (EntryClass.NewSubType == Entry.EntrySubTypes.BitFlag) 
-            {
-                TheWorkshop.PropertiesEntryBitFlag1Name.Text = EntryClass.EntryTypeBitFlag.BitFlag1Name;
-                TheWorkshop.PropertiesEntryBitFlag2Name.Text = EntryClass.EntryTypeBitFlag.BitFlag2Name;
-                TheWorkshop.PropertiesEntryBitFlag3Name.Text = EntryClass.EntryTypeBitFlag.BitFlag3Name;
-                TheWorkshop.PropertiesEntryBitFlag4Name.Text = EntryClass.EntryTypeBitFlag.BitFlag4Name;               
-                
-                TheWorkshop.PropertiesEntryBitFlag5Name.Text = EntryClass.EntryTypeBitFlag.BitFlag5Name;
-                TheWorkshop.PropertiesEntryBitFlag6Name.Text = EntryClass.EntryTypeBitFlag.BitFlag6Name;
-                TheWorkshop.PropertiesEntryBitFlag7Name.Text = EntryClass.EntryTypeBitFlag.BitFlag7Name;
-                TheWorkshop.PropertiesEntryBitFlag8Name.Text = EntryClass.EntryTypeBitFlag.BitFlag8Name;
-            }
-
-
-            if (EntryClass.NewSubType == Entry.EntrySubTypes.Menu) 
-            {
-                TheWorkshop.DropdownMenuType.IsEnabled = true;
-                if (EntryClass.EntryTypeMenu.MenuType == EntryTypeMenu.MenuTypes.Dropdown) { TheWorkshop.MenuTypeItemDropdown.IsSelected = true; }
-                else if (EntryClass.EntryTypeMenu.MenuType == EntryTypeMenu.MenuTypes.List) { TheWorkshop.MenuTypeItemList.IsSelected = true; }
-                
-                
-            }
-
-            TheWorkshop.UpdateSymbology(EntryClass);
-
-
-        } //End of UpdateEntryProperties Method
+        }
 
 
 

--- a/Styles/ApplicationStyle.xaml
+++ b/Styles/ApplicationStyle.xaml
@@ -17,7 +17,14 @@
     -->
 
 
-
+    <Style TargetType="{x:Type Run}">
+        <Setter Property="TextOptions.TextFormattingMode" Value="Display"/>
+        <Setter Property="TextOptions.TextRenderingMode" Value="Aliased"/>
+        <!--<Setter Property="FontSize" Value="16" />-->
+        <Setter Property="FontSize" Value="20" />
+        <Setter Property="FontFamily" Value="Dawns 10px ArkPixel" />
+        <Setter Property="Foreground" Value="{DynamicResource ResourceKey= ApplicationText}"/>
+    </Style>
 
 
     <!--Application-->
@@ -453,7 +460,7 @@
     </Style>
 
     <Style TargetType="{x:Type DockPanel}" x:Key="RowStyle">
-        <Setter Property="Background" Value="#1d1d1d"/> <!--Value="{StaticResource ResourceKey=DarkMode_Middle}"-->
+        <Setter Property="Background" Value="#141114"/> <!--Value="{StaticResource ResourceKey=DarkMode_Middle}"-->
     </Style>
 
 

--- a/User Controls/FileManager.xaml.cs
+++ b/User Controls/FileManager.xaml.cs
@@ -97,8 +97,8 @@ namespace GameEditorStudio
                 {
                     TreeViewItem TreeViewItem = new TreeViewItem();
 
-                    TreeViewItem.Tag = GameFile;
-                    TreeViewItem.ToolTip = GameFile.FileNotepad; 
+                    TreeViewItem.Tag = GameFile;                    
+                        
                     TreeGameFiles.Items.Add(TreeViewItem);
 
                     FileItemNameBuilder(TreeViewItem);
@@ -204,6 +204,19 @@ namespace GameEditorStudio
             TextBlockItem.Inlines.Add(FileNameText);
             TextBlockItem.Inlines.Add(FileNote);
             TreeViewItem.Header = TextBlockItem;
+
+
+            TreeViewItem.Tag = GameFile;
+            if (GameFile.FileNotepad == "")
+            {
+                TreeViewItem.ToolTip = null;
+                FileNameText.TextDecorations = null;
+            }
+            else
+            {
+                TreeViewItem.ToolTip = GameFile.FileNotepad;
+                FileNameText.TextDecorations = TextDecorations.Underline;
+            }
         }
 
         
@@ -380,7 +393,7 @@ namespace GameEditorStudio
             if (treeViewItem == null) { return; }
             GameFile GameFile = treeViewItem.Tag as GameFile;
             GameFile.FileNotepad = FileNotepadTextbox.Text;
-            treeViewItem.ToolTip = GameFile.FileNotepad; // Update the tooltip to show the notepad text
+            FileItemNameBuilder(treeViewItem);
         }
 
         public void SelectItem(Entry Entry) //Sometimes i can't select a item cause this didn't load yet, so this event makes sure it can.

--- a/Windows/Workshop.xaml
+++ b/Windows/Workshop.xaml
@@ -513,7 +513,7 @@
                                                 <Border  DockPanel.Dock="Top">
                                                     <DockPanel>
                                                         <DockPanel DockPanel.Dock="Top" Style="{DynamicResource HeaderDock}">
-                                                            <Label Content="Entry Notepad" FontWeight="Bold"/>
+                                                            <Label Content="Entry Tooltip" FontWeight="Bold"/>
                                                         </DockPanel>
                                                         <TextBox MinHeight="100" x:Name="EntryNoteTextbox" Margin="10" AcceptsReturn="True" TextWrapping="Wrap" VerticalScrollBarVisibility="Auto" TextChanged="EntryNoteTextboxTextChanged"/>
                                                     </DockPanel>

--- a/Windows/Workshop.xaml.cs
+++ b/Windows/Workshop.xaml.cs
@@ -1184,43 +1184,51 @@ namespace GameEditorStudio
         {
             ItemInfo ItemInfo = TreeItem.Tag as ItemInfo;
             TextBlock TextBlockItem = new TextBlock();
-            Run run1 = new Run();
-            if (Properties.Settings.Default.ShowItemIndex == true)
+
+            if (ItemInfo.IsFolder == false)
             {
-                run1.Text = ItemInfo.ItemIndex + ": " + ItemInfo.ItemName + " ";
+                if (Properties.Settings.Default.ShowItemIndex == true)
+                {
+                    Run RunIndex = new Run();
+                    RunIndex.Text = ItemInfo.ItemIndex + ": ";
+                    TextBlockItem.Inlines.Add(RunIndex);
+                }                
+
+                
             }
-            else if (Properties.Settings.Default.ShowItemIndex == false)
-            {
-                run1.Text = ItemInfo.ItemName + " ";
-            }
+
             if (ItemInfo.IsFolder == true)
             {
-                Run runFolder = new Run();
-                runFolder.Foreground = Brushes.Yellow;
-                runFolder.Text = "📁 ";
-                run1.Text = ItemInfo.ItemName + " "; //We never show the index of a folder.
-                TextBlockItem.Inlines.Add(runFolder);
+                Run RunFolder = new Run();
+                RunFolder.Foreground = Brushes.Yellow;
+                RunFolder.Text = "📁 ";
+                TextBlockItem.Inlines.Add(RunFolder);
+
+                Run RunFolderCount = new Run();
+                RunFolderCount.Text = "(" + TreeItem.Items.Count.ToString() + ") ";
+                TextBlockItem.Inlines.Add(RunFolderCount);
             }
 
-            Run run2 = new Run();
-            string sdf = TreeItem.Items.Count.ToString();
-            run2.Text = "(" + sdf + ")";
+            Run RunMain = new Run();
+            RunMain.Text = ItemInfo.ItemName;
+            TextBlockItem.Inlines.Add(RunMain);
 
+            Run RunNote = new Run();
+            RunNote.Text = " " + ItemInfo.ItemNote;
+            RunNote.Foreground = Brushes.Orange; // Set the foreground to red   DeepSkyBlue
+            TextBlockItem.Inlines.Add(RunNote);
 
-            // Create the second part of the text
-            Run run3 = new Run();
-            run3.Text = ItemInfo.ItemNote;
-            run3.Foreground = Brushes.Orange; // Set the foreground to red   DeepSkyBlue
+            if (ItemInfo.ItemNotepad == "")
+            {
+                TreeItem.ToolTip = null;
+                RunMain.TextDecorations = null;
 
-            // Add the runs to the text block
-            TextBlockItem.Inlines.Add(run1);
-            if (ItemInfo.IsFolder == true) { TextBlockItem.Inlines.Add(run2); }
-            TextBlockItem.Inlines.Add(run3);
-
-
-            
-
-            if (ItemInfo.ItemNotepad != "") { TreeItem.ToolTip = ItemInfo.ItemNotepad; }
+            }
+            if (ItemInfo.ItemNotepad != "") 
+            { 
+                TreeItem.ToolTip = ItemInfo.ItemNotepad;
+                RunMain.TextDecorations = TextDecorations.Underline;
+            }
 
 
             TreeItem.Header = TextBlockItem;
@@ -1484,33 +1492,7 @@ namespace GameEditorStudio
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         ////////////////////////////////////////////////////ENTRY PROPERTIES//////////////////////////////////////////////////////////////////
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-        public void LabelWidth(Column ColumnClass)
-        {
-            
-
-            double maxWidth = 0;
-            var EntryList = ColumnClass.EntryList;
-
-            // Measure the desired width of each label without restrictions
-            foreach (Entry entry in EntryList)
-            {
-                entry.EntryLabel.MinWidth = 0;
-                entry.EntryLabel.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
-                double labelWidth = entry.EntryLabel.DesiredSize.Width;
-                if (labelWidth > maxWidth)
-                {
-                    maxWidth = labelWidth;
-                }
-            }
-
-            // Set the MinWidth of each label to the widest value
-            foreach (Entry entry in EntryList)
-            {
-                entry.EntryLabel.MinWidth = maxWidth;
-            }
-        }
-                
+  
 
         private void PropertiesEntryNameBox_KeyDown(object sender, KeyEventArgs e)
         {
@@ -1526,32 +1508,59 @@ namespace GameEditorStudio
 
         public void UpdateEntryName(Entry TheEntry) 
         {
-            if (EntryClass.Name == "")
-            {
-                EntryClass.EntryLabel.Content = "??? " + TheEntry.RowOffset;
-            }
-            if (EntryClass.Name != "") 
-            {
-                EntryClass.EntryLabel.Content = PropertiesNameBox.Text;
-            }
-            
+            //if (EntryClass.Name == "")
+            //{
+            //    EntryClass.EntryLabel.Content = "??? " + TheEntry.RowOffset;
+            //}
+            //if (EntryClass.Name != "") 
+            //{
+            //    EntryClass.EntryLabel.Content = PropertiesNameBox.Text;
+            //}
+
+            //if (ItemInfo.ItemNotepad == "")
+            //{
+            //    TreeItem.ToolTip = null;
+            //    run1.TextDecorations = null;
+
+            //}
+            //if (ItemInfo.ItemNotepad != "")
+            //{
+            //    TreeItem.ToolTip = ItemInfo.ItemNotepad;
+            //    run1.TextDecorations = TextDecorations.Underline;
+            //}
+
+            //if (EntryClass.Notepad == "")
+            //{
+            //    EntryClass.EntryLabel.ToolTip = null;
+            //}
+            //else //if (EntryClass.Name != "")
+            //{
+            //    EntryClass.EntryLabel.ToolTip = EntryClass.Notepad;
+            //    //EntryClass.EntryLabel.
+            //}
+
 
             MyDatabase.EntryManager.LoadEntry(this, EditorClass, EntryClass);
-            Dispatcher.InvokeAsync(() => LabelWidth(EntryClass.EntryColumn), System.Windows.Threading.DispatcherPriority.Loaded);
-            LabelWidth(EntryClass.EntryColumn);
+
+            StandardEditorMethods.UpdateEntryName(EntryClass);
+
+            Dispatcher.InvokeAsync(() => StandardEditorMethods.LabelWidth(EntryClass.EntryColumn), System.Windows.Threading.DispatcherPriority.Loaded);
+            StandardEditorMethods.LabelWidth(EntryClass.EntryColumn);
         }
         
 
         private void HideNameCheckboxChecked(object sender, RoutedEventArgs e)
         {
             EntryClass.IsNameHidden = true;
-            EntryClass.EntryLabel.Visibility = Visibility.Collapsed;
+            StandardEditorMethods.UpdateEntryName(EntryClass);
+            //EntryClass.EntryLabel.Visibility = Visibility.Collapsed;
         }
 
         private void HideNameCheckboxUnchecked(object sender, RoutedEventArgs e)
         {
             EntryClass.IsNameHidden = false;
-            EntryClass.EntryLabel.Visibility = Visibility.Visible;
+            StandardEditorMethods.UpdateEntryName(EntryClass);
+            //EntryClass.EntryLabel.Visibility = Visibility.Visible;
         }
 
         private void HideEntryCheckboxChecked(object sender, RoutedEventArgs e)
@@ -2250,6 +2259,7 @@ namespace GameEditorStudio
         {
             if (EditorClass == null) { return; }
             EditorClass.StandardEditorData.SelectedEntry.Notepad = EntryNoteTextbox.Text;
+            StandardEditorMethods.UpdateEntryName(EditorClass.StandardEditorData.SelectedEntry);
         }
 
         private void PropertiesMenuType_DropDownClosed(object sender, EventArgs e)


### PR DESCRIPTION
- Files and Items don't get a empty tooltip if the file doesn't even have any notepad text.

- Files and Items get underlined text if they have a tooltip / notepad text.

- I also got both working for entrys, but it took like 15x longer.

- The loading time of selecting an item in the left bar has been lowered for a 800 entry editor from 6700ms to 2ms average.

- I COINCIDENTALLY managed to make it so entrys that are hiding their name are aligned properly.

- I still really want entry groups to exist before release, and i still am scared of how much effort it will take :(, i also axidentally caused a problem with the appearence of bitflags i'll need to fix, which actually i already wanted to change them anyway, so maybe i get to fix two at once later.