### PR TITLE
Notepads become Tooltips, and Entry Group code starts.

### DIFF
--- a/Commands (Tools, Events, Methods, etc)/CM_Saves.cs
+++ b/Commands (Tools, Events, Methods, etc)/CM_Saves.cs
@@ -259,7 +259,7 @@ namespace GameEditorStudio
                                                                         
                                     writer.WriteElementString("Index", data.ItemIndex.ToString());
                                     writer.WriteElementString("Note", data.ItemNote);
-                                    writer.WriteElementString("Notepad", data.ItemNotepad);
+                                    writer.WriteElementString("Tooltip", data.ItemWorkshopTooltip);
                                     writer.WriteElementString("Key", data.ItemKey);
 
                                     // Handle nested items or folders
@@ -305,7 +305,7 @@ namespace GameEditorStudio
                                         {
                                             writer.WriteStartElement("Entry");                                            
                                             writer.WriteElementString("Name", entry.Name);
-                                            writer.WriteElementString("Notepad", entry.Notepad);
+                                            writer.WriteElementString("Tooltip", entry.WorkshopTooltip);
                                             writer.WriteElementString("IsNameHidden", entry.IsNameHidden.ToString());
                                             writer.WriteElementString("IsEntryHidden", entry.IsEntryHidden.ToString());  
                                             writer.WriteElementString("RowOffset", entry.RowOffset.ToString());
@@ -566,7 +566,7 @@ namespace GameEditorStudio
                                 FileWriter.WriteElementString("Name", AGameFile.FileName);
                                 FileWriter.WriteElementString("Location", AGameFile.FileLocation);
                                 FileWriter.WriteElementString("Note", AGameFile.FileNote);
-                                FileWriter.WriteElementString("Notepad", AGameFile.FileNotepad);
+                                FileWriter.WriteElementString("Tooltip", AGameFile.FileWorkshopTooltip);
                                 FileWriter.WriteEndElement();
                             }
 

--- a/Databases/StandardEditorData.cs
+++ b/Databases/StandardEditorData.cs
@@ -108,7 +108,7 @@ namespace GameEditorStudio
         public string ItemName { get; set; } = ""; //XML
         public int ItemIndex { get; set; } = 0; //XML Basically, the row number in a table. Note: Folders have a index of 0.   I should maybe update this so folders have an index of -1. //Basically a Key
         public string ItemKey { get; set; } = LibraryMan.GenerateKey(); //This is only incase it's needed for future features, but is currently unused. 
-        public string? ItemNotepad { get; set; } = ""; //XML the orange one
+        public string? ItemWorkshopTooltip { get; set; } = ""; //XML the orange one
         public string ItemNote { get; set; } = ""; //XML The actual note?
         public bool IsChild { get; set; } = false;
         public bool IsFolder { get; set; } = false; //NOT XML  //new folder is in workshop.cs
@@ -132,7 +132,7 @@ namespace GameEditorStudio
     public class Column
     {
         public string ColumnName { get; set; } = "New Column"; //XML The name of a column.
-        public DockPanel? ColumnGrid { get; set; }
+        public DockPanel? ColumnPanel { get; set; }
         public List<Entry>? EntryList { get; set; } = new();
 
         public List<CItem>? MasterList { get; set; } = new();
@@ -149,9 +149,11 @@ namespace GameEditorStudio
     public class Group : CItem //A way to group entries together, like a folder.
     {
         public string GroupName { get; set; } = "New Group"; //XML The name of a column.
-        public DockPanel? GroupPanel { get; set; }
-        public List<Entry>? EntryList { get; set; } = new();
-        public Label GroupLabel { get; set; }
+        public string GroupTooltip { get; set; } = "";
+        public Border GroupBorder { get; set; } = new();
+        public DockPanel GroupPanel { get; set; } = new();
+        public List<Entry> EntryList { get; set; } = new();
+        public Label GroupLabel { get; set; } = new();
         public Column GroupColumn { get; set; }
         public string Key { get; set; } = LibraryMan.GenerateKey(); //Unused, Only exists incase of future features. 
     }
@@ -160,7 +162,7 @@ namespace GameEditorStudio
     public class Entry : CItem
     {
         public string Name { get; set; } = "";  //XML //The Name / Label an entry Gets. Later, it will default to "???"  
-        public string Notepad { get; set; } = ""; //XML
+        public string WorkshopTooltip { get; set; } = ""; //XML
         public bool IsNameHidden { get; set; } = false;  //XML //Yes or No, Defaults to Yes
         public bool IsEntryHidden { get; set; } = false;  //XML  -Enabled or Disabled (AutoDisabled?)//Decides If entry can save to Memory File. Occurs when the byte is also in use by the NameTable or any ExtraTables.  
         public bool IsTextInUse { get; set; } = false; //Not XML //if true, this entry actually represents name or description text, and is basically disabled / hidden. 
@@ -205,6 +207,7 @@ namespace GameEditorStudio
         public Editor EntryEditor { get; set; }
         public Category EntryRow { get; set; }
         public Column EntryColumn { get; set; }
+        public Group EntryGroup { get; set; }
 
         //The grid/Dockpanel? The labels and buttons to later delete?
 

--- a/Databases/TrueDatabase.cs
+++ b/Databases/TrueDatabase.cs
@@ -66,7 +66,7 @@ namespace GameEditorStudio
         public string FileName { get; set; } = ""; //XML The actual name of the file
         public string FileLocation { get; set; } = ""; //XML The path from InputDirectory to the FileName.
         public string FileNote { get; set; } = ""; //XML. For games that have multiple files with identical names via being in diffrent folders, users can give files a nickname, but save as their real name.
-        public string FileNotepad { get; set; } = ""; //XML (or it will be)
+        public string FileWorkshopTooltip { get; set; } = ""; //XML (or it will be)
         public byte[] FileBytes { get; set; } //Not XML  //The actual loaded information from a file. This is what editors edit! This is the ENTIRE file, not just a table of bytes.
         //FileBytes is also reffered to in comments as "Memory File" due to it being a version of the file entirely in memory, and not saved back to the computer.
         //"Memory File" helps differenciate between the file's origonal bytes, and it's current ones after editing but before saving.

--- a/Editors/LoadFiles&Editors.cs
+++ b/Editors/LoadFiles&Editors.cs
@@ -43,7 +43,7 @@ namespace GameEditorStudio.Loading
                     FileInfo.FileName = FileX.Element("Name")?.Value;
                     FileInfo.FileLocation = FileX.Element("Location")?.Value;
                     FileInfo.FileNote = FileX.Element("Note")?.Value;
-                    FileInfo.FileNotepad = FileX.Element("Notepad")?.Value;
+                    FileInfo.FileWorkshopTooltip = FileX.Element("Tooltip")?.Value;
 
                     bool GameFileExists = false;
                     foreach (GameFile GameFile in Database.GameFiles.Values) 

--- a/Editors/MakeButton.cs
+++ b/Editors/MakeButton.cs
@@ -266,7 +266,7 @@ namespace GameEditorStudio
                         TheWorkshop.PropertiesEditorNameTableCharacterSetDropdown.IsEnabled = false;
                     }
 
-                    TheWorkshop.EntryNoteTextbox.Text = TheEditorClass.StandardEditorData.SelectedEntry.Notepad;
+                    TheWorkshop.EntryNoteTextbox.Text = TheEditorClass.StandardEditorData.SelectedEntry.WorkshopTooltip;
 
 
 

--- a/Editors/Standard/GenerateStandardEditor.cs
+++ b/Editors/Standard/GenerateStandardEditor.cs
@@ -45,6 +45,7 @@ namespace GameEditorStudio
         Point mouseDragStartPoint;
         Point scrollStartOffset;
 
+
         private void ScrollViewer_PreviewMouseDown(object sender, MouseButtonEventArgs e)
         {
             if (e.ChangedButton == MouseButton.Middle)
@@ -540,7 +541,7 @@ namespace GameEditorStudio
                 {
                     foreach (Column column in CatClass.ColumnList)
                     {
-                        column.ColumnGrid.Visibility = Visibility.Collapsed;
+                        column.ColumnPanel.Visibility = Visibility.Collapsed;
                     }
                     Button.Content = "Show Row";
                 }
@@ -549,7 +550,7 @@ namespace GameEditorStudio
                 {
                     foreach (Column column in CatClass.ColumnList)
                     {
-                        column.ColumnGrid.Visibility = Visibility.Visible;
+                        column.ColumnPanel.Visibility = Visibility.Visible;
                     }
                     Button.Content = "Hide Row";
                 }
@@ -614,11 +615,7 @@ namespace GameEditorStudio
             Header.ContextMenu = ContextMenu;
 
         }
-
-        public void CreateGroup() 
-        {
-        
-        }
+                
 
         public void CreateColumn(Category RowClass, Column ColumnClass, Workshop TheWorkshop, WorkshopData Database, int Index)
         {
@@ -626,7 +623,7 @@ namespace GameEditorStudio
 
             DockPanel ColumnGrid = new DockPanel();
             ColumnGrid.Style = (Style)Application.Current.Resources["ColumnStyle"];
-            ColumnGrid.MinWidth = 70;
+            ColumnGrid.MinWidth = 30;
             //ColumnGrid.Width = 400;
             //ColumnGrid.Height = 200;
             ColumnGrid.VerticalAlignment = VerticalAlignment.Top; //Top Bottom
@@ -644,8 +641,8 @@ namespace GameEditorStudio
             if (Index == -1) { RowClass.CategoryDockPanel.Children.Add(ColumnGrid); }
             else { ColumnClass.ColumnRow.CategoryDockPanel.Children.Insert(Index + 1, ColumnGrid); }
             //PageClass.Grid.Children.Add(ButtonAddRow);
-            ColumnClass.ColumnGrid = new();
-            ColumnClass.ColumnGrid = ColumnGrid;
+            ColumnClass.ColumnPanel = new();
+            ColumnClass.ColumnPanel = ColumnGrid;
 
 
             DockPanel Header = new(); //The top part of a column, where the label is, and you can right click this part, and only this part, for a context menu.
@@ -780,12 +777,12 @@ namespace GameEditorStudio
                     {
                         //Note to self: Add a check for if the Category the group is leaving, is now empty. If so, kill it.
 
-                        InputColumn.ColumnRow.CategoryDockPanel.Children.Remove(InputColumn.ColumnGrid);
+                        InputColumn.ColumnRow.CategoryDockPanel.Children.Remove(InputColumn.ColumnPanel);
                         int FromIndex = InputColumn.ColumnRow.ColumnList.IndexOf(InputColumn);
-                        int ToIndex = ColumnClass.ColumnRow.CategoryDockPanel.Children.IndexOf(ColumnClass.ColumnGrid);
+                        int ToIndex = ColumnClass.ColumnRow.CategoryDockPanel.Children.IndexOf(ColumnClass.ColumnPanel);
                         InputColumn.ColumnRow.ColumnList.RemoveAt(FromIndex);
 
-                        ColumnClass.ColumnRow.CategoryDockPanel.Children.Insert(ToIndex + 1, InputColumn.ColumnGrid);
+                        ColumnClass.ColumnRow.CategoryDockPanel.Children.Insert(ToIndex + 1, InputColumn.ColumnPanel);
                         ColumnClass.ColumnRow.ColumnList.Insert(ToIndex, InputColumn);
 
                         //InputColumn.ColumnRow = ColumnClass.ColumnRow; //DO NOT REFER TO COLUMN CLASS DIRECTLY, ALTHOUGH I DONT REMEMBER WHY.                    
@@ -816,7 +813,7 @@ namespace GameEditorStudio
                 {
                     Entry InputEntry = (Entry)e.Data.GetData("MoveEntryClass");
 
-                    InputEntry.EntryColumn.ColumnGrid.Children.Remove(InputEntry.EntryBorder);
+                    InputEntry.EntryColumn.ColumnPanel.Children.Remove(InputEntry.EntryBorder);
                     int FromIndex = InputEntry.EntryColumn.EntryList.IndexOf(InputEntry);
                     InputEntry.EntryColumn.EntryList.RemoveAt(FromIndex);
 
@@ -836,7 +833,7 @@ namespace GameEditorStudio
 
                         var InputEntry = TheWorkshop.EntryMoveList[i];
 
-                        InputEntry.EntryColumn.ColumnGrid.Children.Remove(InputEntry.EntryBorder);
+                        InputEntry.EntryColumn.ColumnPanel.Children.Remove(InputEntry.EntryBorder);
                         InputEntry.EntryColumn.EntryList.RemoveAt(InputEntry.EntryColumn.EntryList.IndexOf(InputEntry));
 
                         ColumnGrid.Children.Insert(1 + i, InputEntry.EntryBorder);
@@ -873,6 +870,11 @@ namespace GameEditorStudio
 
                 StandardEditorMethods.EntryActivate(TheWorkshop, TheWorkshop.EntryClass); //this prevents a crash when immedietly merging the moved entry into a 2 byte.
             }
+
+        }
+
+        public void CreateGroup()
+        {
 
         }
 
@@ -935,11 +937,19 @@ namespace GameEditorStudio
             //EntryToNewGroup.Click += new RoutedEventHandler(NewGroup);
             //void NewGroup(object sender, RoutedEventArgs e)
             //{
-                
+
             //}
 
-                      
 
+            MenuItem EntryCreateNewGroup = new MenuItem();
+            EntryCreateNewGroup.Header = "  Create new group  ";
+            contextMenu.Items.Add(EntryCreateNewGroup);
+            EntryCreateNewGroup.Click += new RoutedEventHandler(NewColumnGroup);
+            void NewColumnGroup(object sender, RoutedEventArgs e)
+            {
+                StandardEditorMethods.CreateNewGroup(EntryClass);
+
+            }
 
             MenuItem EntryToNewLeftColumn = new MenuItem();
             EntryToNewLeftColumn.Header = "  Move into New Column  (Left)  ";
@@ -985,17 +995,7 @@ namespace GameEditorStudio
                 StandardEditorMethods.MoveEntrysToColumn(ListOfEntrys, toColumn);
             }
 
-            MenuItem EntryCreateNewGroup = new MenuItem();
-            EntryCreateNewGroup.Header = "  Create new group  ";
-            contextMenu.Items.Add(EntryCreateNewGroup);
-            EntryCreateNewGroup.Click += new RoutedEventHandler(NewColumnGroup);
-            void NewColumnGroup(object sender, RoutedEventArgs e)
-            {
-                StandardEditorMethods.CreateNewGroup(EntryClass);
-                
-            }
-
-
+            
 
 
 
@@ -1010,6 +1010,7 @@ namespace GameEditorStudio
                 else
                 {      
                     StandardEditorMethods.EntryActivate(TheWorkshop, EntryClass);
+                    //e.Handled = true; // 🛑 Prevent the entry's parent from stealing the click event.
                 }
 
                 
@@ -1143,7 +1144,7 @@ namespace GameEditorStudio
 
 
 
-            ColumnClass.ColumnGrid.Children.Add(Border);
+            ColumnClass.ColumnPanel.Children.Add(Border);
             Border.Child = EntryDockPanel;
             EntryClass.EntryDockPanel = new();
             EntryClass.EntryDockPanel = EntryDockPanel;

--- a/Editors/Standard/LoadStandardEditor.cs
+++ b/Editors/Standard/LoadStandardEditor.cs
@@ -245,7 +245,7 @@ namespace GameEditorStudio
                             ItemName = element.Element("Name")?.Value ?? "Unnamed",
                             ItemIndex = int.Parse(element.Element("Index")?.Value ?? "0"),
                             ItemNote = element.Element("Note")?.Value,
-                            ItemNotepad = element.Element("Notepad")?.Value,
+                            ItemWorkshopTooltip = element.Element("Tooltip")?.Value,
                             ItemKey = element.Element("Key")?.Value,
 
                         };
@@ -323,7 +323,7 @@ namespace GameEditorStudio
                         EditorClass.StandardEditorData.MasterEntryList.Add(EntryClass);
 
                         EntryClass.Name = Xentry.Element("Name")?.Value;
-                        EntryClass.Notepad = Xentry.Element("Notepad")?.Value;
+                        EntryClass.WorkshopTooltip = Xentry.Element("Tooltip")?.Value;
                         EntryClass.IsNameHidden = Convert.ToBoolean(Xentry.Element("IsNameHidden")?.Value);
                         EntryClass.IsEntryHidden = Convert.ToBoolean(Xentry.Element("IsEntryHidden")?.Value);
                         EntryClass.TableKey = Xentry.Element("TableKey")?.Value;

--- a/Game Editor Studio.csproj
+++ b/Game Editor Studio.csproj
@@ -17,8 +17,6 @@
     <SelfContained>true</SelfContained>
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier> <!-- Or win-x86 if needed -->
-	<DebugType>none</DebugType>
-	<DebugSymbols>false</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Main/LibraryMan.cs
+++ b/Main/LibraryMan.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
 using System.Windows.Media;
 using Ookii.Dialogs.Wpf;
 using Windows.UI.Notifications;
@@ -541,7 +542,13 @@ namespace GameEditorStudio
             }
         }
 
+
+
+
+
+
         
+
 
 
     }

--- a/User Controls/FileManager.xaml
+++ b/User Controls/FileManager.xaml
@@ -45,10 +45,10 @@
                     <TextBox x:Name="FileLocationTextbox" Grid.Row="0" Grid.Column="1" Width="Auto" Margin="3" TextChanged="FileLocationTextboxTextChanged"/>
 
                     <Label Content="File Note" Grid.Row="1" Grid.Column="0"/>
-                    <TextBox x:Name="FileNoteBox" Grid.Row="1" Grid.Column="1" Margin="3" TextChanged="FileNoteBoxTextChanged"  />
+                    <TextBox x:Name="FileNoteBox" Grid.Row="1" Grid.Column="1" Margin="3" TextChanged="FileNoteBoxTextChanged" ToolTip="Write a note that appears next to the filename. Great for files with similuar or identical names. "  />
 
                     <ScrollViewer Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" Margin="3" VerticalScrollBarVisibility="Auto">
-                        <TextBox x:Name="FileNotepadTextbox" TextWrapping="Wrap"  TextChanged="FileNotepadTextChanged" />
+                        <TextBox x:Name="FileNotepadTextbox" TextWrapping="Wrap"  TextChanged="FileNotepadTextChanged" ToolTip="Write a tooltip for the file. :)" />
                     </ScrollViewer>
                     
                 </Grid>

--- a/User Controls/FileManager.xaml.cs
+++ b/User Controls/FileManager.xaml.cs
@@ -198,7 +198,7 @@ namespace GameEditorStudio
             FileNameText.Text = GameFile.FileName;
 
             Run FileNote = new Run();
-            FileNote.Text = "   " + GameFile.FileNote;
+            FileNote.Text = " " + GameFile.FileNote;
             FileNote.Foreground = Brushes.Orange;
 
             TextBlockItem.Inlines.Add(FileNameText);
@@ -207,14 +207,14 @@ namespace GameEditorStudio
 
 
             TreeViewItem.Tag = GameFile;
-            if (GameFile.FileNotepad == "")
+            if (GameFile.FileWorkshopTooltip == "")
             {
                 TreeViewItem.ToolTip = null;
                 FileNameText.TextDecorations = null;
             }
             else
             {
-                TreeViewItem.ToolTip = GameFile.FileNotepad;
+                TreeViewItem.ToolTip = GameFile.FileWorkshopTooltip;
                 FileNameText.TextDecorations = TextDecorations.Underline;
             }
         }
@@ -233,7 +233,7 @@ namespace GameEditorStudio
             }
             GameFile GameFile = treeViewItem.Tag as GameFile;
             FileNoteBox.Text = GameFile.FileNote;
-            FileNotepadTextbox.Text = GameFile.FileNotepad;
+            FileNotepadTextbox.Text = GameFile.FileWorkshopTooltip;
             FileLocationTextbox.Text = GameFile.FileLocation;
 
             {
@@ -392,7 +392,7 @@ namespace GameEditorStudio
             TreeViewItem treeViewItem = TreeGameFiles.SelectedItem as TreeViewItem;
             if (treeViewItem == null) { return; }
             GameFile GameFile = treeViewItem.Tag as GameFile;
-            GameFile.FileNotepad = FileNotepadTextbox.Text;
+            GameFile.FileWorkshopTooltip = FileNotepadTextbox.Text;
             FileItemNameBuilder(treeViewItem);
         }
 

--- a/User Controls/TheLeftBar.xaml
+++ b/User Controls/TheLeftBar.xaml
@@ -50,7 +50,7 @@
                     <Label Content="Note" Grid.Row="1" Grid.Column="0"/>
                     <TextBox x:Name="ItemNoteTextbox" Grid.Row="1" Grid.Column="1" Margin="3" KeyDown="ItemNoteboxKeyDown" ToolTip="An item note is displayed next to the item in the items list.&#xD;&#xA;It does not get saved to the game files.&#xD;&#xA;Item note data is a part of the editor, not a project. " />
 
-                    <TextBox x:Name="ItemNotepadTextbox" Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" Margin="3" TextChanged="NotepadTextChanged" ToolTip="An item notepad is a longform note for the item.&#xD;&#xA;Unlike a note, it doesn't display next to the item, and only appears in this textbox.&#xD;&#xA;It is still very useful for keeping track of detailed information.&#xD;&#xA;Item notepad data is a part of the editor, not a project." />
+                    <TextBox x:Name="ItemNotepadTextbox" Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2" Margin="3" TextChanged="NotepadTextChanged" ToolTip="This is where you write a tooltip for the item.&#xD;&#xA;Items with a tooltip appear underlined, and hovering the mouse on them shows the tooltip.&#xD;&#xA;It also supports linebreaks (the enter key), go nuts.&#xD;&#xA;Item Tooltips are part of the editor, not a mod / project, but support for that is coming later." />
                 </Grid>
             </DockPanel>
         </ContentControl>

--- a/User Controls/TheLeftBar.xaml.cs
+++ b/User Controls/TheLeftBar.xaml.cs
@@ -42,6 +42,7 @@ namespace GameEditorStudio
             TheWorkshop = AWorkshop;
             Database = ADatabase;
             EditorClass = AEditor;
+            
 
             EditorClass.StandardEditorData.EditorLeftDockPanel.LeftBarDockPanel.Children.Add(this);
             EditorClass.StandardEditorData.EditorLeftDockPanel.SearchBar = SearchBar;
@@ -493,7 +494,7 @@ namespace GameEditorStudio
                 if (selectedInfo != null)
                 {
                     // Update the Name property with the text from the TextBox
-                    selectedInfo.ItemNotepad = ItemNotepadTextbox.Text;
+                    selectedInfo.ItemWorkshopTooltip = ItemNotepadTextbox.Text;
                     TheWorkshop.ItemNameBuilder(selectedItem);
                 }
             }
@@ -516,7 +517,7 @@ namespace GameEditorStudio
                 }
 
                 EditorClass.StandardEditorData.EditorLeftDockPanel.ItemNoteTextbox.Text = data.ItemNote;
-                EditorClass.StandardEditorData.EditorLeftDockPanel.ItemNotepadTextbox.Text = data.ItemNotepad;
+                EditorClass.StandardEditorData.EditorLeftDockPanel.ItemNotepadTextbox.Text = data.ItemWorkshopTooltip;
 
                 if (EditorClass.StandardEditorData.DescriptionTableList.Count > 0)
                 {
@@ -604,6 +605,15 @@ namespace GameEditorStudio
             if (EditorClass.StandardEditorData.FileNameTable == null) { LabelCharacterCount.Content = "Fake Name List"; }
         }
 
-        
+
+
+
+
+
+
+
+
+
+
     }
 }

--- a/Windows/Workshop.xaml
+++ b/Windows/Workshop.xaml
@@ -325,6 +325,40 @@
                                                 </Border>
                                             </DockPanel>
                                         </TabItem>
+                                        <TabItem Name="GeneralGroup" Header="Group" Margin="0,0,1,0" FontSize="18"  Padding="9,0,9,0" BorderThickness="1,0,1,0">
+                                            <DockPanel  >
+                                                <!--Margin="-2"-->
+                                                <Border DockPanel.Dock="Top"  >
+                                                    <DockPanel Margin="0,0,0,3">
+                                                        <DockPanel Style="{DynamicResource HeaderDock}" DockPanel.Dock="Top" Height="23"  MinHeight="0" Margin="0,0,0,5" >
+                                                            <Label Content="Group" FontWeight="Bold" Margin="5,-5,0,-5"  />
+                                                        </DockPanel>
+                                                        <Grid>
+                                                            <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition Width="5"/>
+                                                                <ColumnDefinition Width="Auto"/>
+                                                                <ColumnDefinition Width="*"/>
+                                                                <ColumnDefinition Width="5"/>
+                                                            </Grid.ColumnDefinitions>
+
+                                                            <Grid.RowDefinitions>
+                                                                <RowDefinition Height="Auto"/>
+                                                                <RowDefinition Height="Auto"/>
+                                                                <RowDefinition Height="Auto"/>
+                                                                <RowDefinition Height="Auto"/>
+
+                                                            </Grid.RowDefinitions>
+
+                                                            <Label Content="Name" Grid.Row="0" Grid.Column="1" Margin="0"/>
+                                                            <TextBox x:Name="PropertiesGroupNameBox" Grid.Row="0" Grid.Column="2" Margin="3" Text="New Group" TextWrapping="Wrap"  KeyDown="PropertiesGroupNameTextBox_KeyDown"/>
+
+                                                            <Label Content="Tooltip" Grid.Row="1" Grid.Column="1" Margin="0"/>
+                                                            <TextBox x:Name="PropertiesGroupTooltipBox" Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="2" Height="100" Margin="3" Text="" TextWrapping="Wrap"  TextChanged="PropertiesGroupTooltipTextBox_TextChanged"/>
+                                                        </Grid>
+                                                    </DockPanel>
+                                                </Border>
+                                            </DockPanel>
+                                        </TabItem>
                                         <TabItem Name="GeneralEntry" Header="Entry" Margin="0,0,0,0" FontSize="18"  Padding="9,0,9,0" BorderThickness="1,0,1,0">
                                             <DockPanel >
                                                 <Border DockPanel.Dock="Top">

--- a/Windows/Workshop.xaml.cs
+++ b/Windows/Workshop.xaml.cs
@@ -76,6 +76,7 @@ namespace GameEditorStudio
         public Editor EditorClass { get; set; }
         public Category CategoryClass { get; set; }
         public Column ColumnClass { get; set; }
+        public Group GroupClass { get; set; }
         public Entry EntryClass { get; set; }
 
         public List<Entry> EntryMoveList  {  get; set; } = new();
@@ -112,6 +113,7 @@ namespace GameEditorStudio
                 (TabTest.FindName("GeneralEditor") as TabItem).Visibility = Visibility.Collapsed;
                 (TabTest.FindName("GeneralRow") as TabItem).Visibility = Visibility.Collapsed;
                 (TabTest.FindName("GeneralColumn") as TabItem).Visibility = Visibility.Collapsed;
+                (TabTest.FindName("GeneralGroup") as TabItem).Visibility = Visibility.Collapsed;
                 (TabTest.FindName("GeneralEntry") as TabItem).Visibility = Visibility.Collapsed;
                 //(TabTest.FindName("GeneralDebug") as TabItem).Visibility = Visibility.Collapsed;
 
@@ -503,17 +505,17 @@ namespace GameEditorStudio
 
                         if (Properties.Settings.Default.ShowHiddenEntrys == true) //Will show / hide the column itself if every entry is hidden and hiddens are not set to visible. 
                         {
-                            column.ColumnGrid.Visibility = Visibility.Visible;
+                            column.ColumnPanel.Visibility = Visibility.Visible;
                         }
                         else if (Properties.Settings.Default.ShowHiddenEntrys == false)
                         {
                             if (ColumnIsVisible == false) 
                             { 
-                                column.ColumnGrid.Visibility = Visibility.Collapsed;
+                                column.ColumnPanel.Visibility = Visibility.Collapsed;
                             }
                             else
                             { 
-                                column.ColumnGrid.Visibility = Visibility.Visible;
+                                column.ColumnPanel.Visibility = Visibility.Visible;
                             }
                         }
                         
@@ -1218,15 +1220,15 @@ namespace GameEditorStudio
             RunNote.Foreground = Brushes.Orange; // Set the foreground to red   DeepSkyBlue
             TextBlockItem.Inlines.Add(RunNote);
 
-            if (ItemInfo.ItemNotepad == "")
+            if (ItemInfo.ItemWorkshopTooltip == "")
             {
                 TreeItem.ToolTip = null;
                 RunMain.TextDecorations = null;
 
             }
-            if (ItemInfo.ItemNotepad != "") 
+            if (ItemInfo.ItemWorkshopTooltip != "") 
             { 
-                TreeItem.ToolTip = ItemInfo.ItemNotepad;
+                TreeItem.ToolTip = ItemInfo.ItemWorkshopTooltip;
                 RunMain.TextDecorations = TextDecorations.Underline;
             }
 
@@ -1443,7 +1445,7 @@ namespace GameEditorStudio
         {
             if (TheColumn.EntryList.Count == 0)
             {
-                TheColumn.ColumnRow.CategoryDockPanel.Children.Remove(TheColumn.ColumnGrid);
+                TheColumn.ColumnRow.CategoryDockPanel.Children.Remove(TheColumn.ColumnPanel);
                 TheColumn.ColumnRow.ColumnList.Remove(TheColumn);
 
                 //LibraryMan.GotoGeneralEditor(this);
@@ -1478,21 +1480,58 @@ namespace GameEditorStudio
 
             }
         }
+
+
+
+
+
+        ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        ///////////////////////////////////////////////////COLUMN PROPERTIES///////////////////////////////////////////////////////////////////
+        ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        //
+        //
+        //
+        ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+        ////////////////////////////////////////////////////GROUP PROPERTIES///////////////////////////////////////////////////////////////////
+        ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+        private void PropertiesGroupNameTextBox_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Enter)
+            {
+                GroupClass.GroupName = PropertiesGroupNameBox.Text;
+                GroupClass.GroupLabel.Content = PropertiesGroupNameBox.Text;
+                
+
+            }
+        }
+
+        private void PropertiesGroupTooltipTextBox_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            GroupClass.GroupTooltip = PropertiesGroupTooltipBox.Text;
+
+            //Hook into a Update Group Tooltip method.
+            if (PropertiesGroupTooltipBox.Text == "") 
+            {
+                
+            }
+            if (PropertiesGroupTooltipBox.Text != "")
+            {
+
+            }
+        }
         
 
-
-
-
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-        ///////////////////////////////////////////////COLUMN PROPERTIES//////////////////////////////////////////////////////////////////////
+        ///////////////////////////////////////////////////GROUP PROPERTIES////////////////////////////////////////////////////////////////////
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
         //
         //
         //
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-        ////////////////////////////////////////////////////ENTRY PROPERTIES//////////////////////////////////////////////////////////////////
+        ////////////////////////////////////////////////////ENTRY PROPERTIES///////////////////////////////////////////////////////////////////
         ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-  
+
 
         private void PropertiesEntryNameBox_KeyDown(object sender, KeyEventArgs e)
         {
@@ -1507,37 +1546,7 @@ namespace GameEditorStudio
         }
 
         public void UpdateEntryName(Entry TheEntry) 
-        {
-            //if (EntryClass.Name == "")
-            //{
-            //    EntryClass.EntryLabel.Content = "??? " + TheEntry.RowOffset;
-            //}
-            //if (EntryClass.Name != "") 
-            //{
-            //    EntryClass.EntryLabel.Content = PropertiesNameBox.Text;
-            //}
-
-            //if (ItemInfo.ItemNotepad == "")
-            //{
-            //    TreeItem.ToolTip = null;
-            //    run1.TextDecorations = null;
-
-            //}
-            //if (ItemInfo.ItemNotepad != "")
-            //{
-            //    TreeItem.ToolTip = ItemInfo.ItemNotepad;
-            //    run1.TextDecorations = TextDecorations.Underline;
-            //}
-
-            //if (EntryClass.Notepad == "")
-            //{
-            //    EntryClass.EntryLabel.ToolTip = null;
-            //}
-            //else //if (EntryClass.Name != "")
-            //{
-            //    EntryClass.EntryLabel.ToolTip = EntryClass.Notepad;
-            //    //EntryClass.EntryLabel.
-            //}
+        {           
 
 
             MyDatabase.EntryManager.LoadEntry(this, EditorClass, EntryClass);
@@ -1843,13 +1852,13 @@ namespace GameEditorStudio
 
                         int MyIndex = entry.EntryColumn.EntryList.IndexOf(entry); //entry.EntryColumn.ColumnGrid.Children.IndexOf(entry.EntryDockPanel);
                         entry.EntryColumn.EntryList.RemoveAt(MyIndex);
-                        entry.EntryColumn.ColumnGrid.Children.Remove(entry.EntryBorder);
+                        entry.EntryColumn.ColumnPanel.Children.Remove(entry.EntryBorder);
 
 
-                        int EntryLocation = ColumnClass.ColumnGrid.Children.IndexOf(EntryClass.EntryBorder) - 1; //Counting starts at 1, but the first child is 0.
+                        int EntryLocation = ColumnClass.ColumnPanel.Children.IndexOf(EntryClass.EntryBorder) - 1; //Counting starts at 1, but the first child is 0.
                         int Diffrence = entry.RowOffset - EntryClass.RowOffset;
                         ColumnClass.EntryList.Insert(EntryLocation + Diffrence, entry);
-                        ColumnClass.ColumnGrid.Children.Insert(EntryLocation + Diffrence + 1, entry.EntryBorder);
+                        ColumnClass.ColumnPanel.Children.Insert(EntryLocation + Diffrence + 1, entry.EntryBorder);
 
 
                         entry.EntryRow = EntryClass.EntryRow;  //  PageClass.RowList[rowIndex + 1];
@@ -2255,10 +2264,11 @@ namespace GameEditorStudio
             }
         }
 
+
         private void EntryNoteTextboxTextChanged(object sender, TextChangedEventArgs e)
         {
             if (EditorClass == null) { return; }
-            EditorClass.StandardEditorData.SelectedEntry.Notepad = EntryNoteTextbox.Text;
+            EditorClass.StandardEditorData.SelectedEntry.WorkshopTooltip = EntryNoteTextbox.Text;
             StandardEditorMethods.UpdateEntryName(EditorClass.StandardEditorData.SelectedEntry);
         }
 
@@ -2674,6 +2684,8 @@ namespace GameEditorStudio
                 UpdateEntryName(EntryClass);
             }
         }
+
+        
     }
 
     public class NumberCount


### PR DESCRIPTION
- The term "Notepad", for saving to XML files, has been replaced with Tooltip. Going forward i plan to treat all notepad like areas as tooltips, as it's more understandable and intuitive i think. Ones in workshop folders are all just called Tooltip, but in code they are called WorkshopTooltip, so that projects can seperate between WorkshopTooltips and ProjectTooltips, as i later plan to expand to allow for users to do that. I origonally wanted it, i pulled back because i thought it to complicated, but now i have a better idea on implimenting it all and will go for it again.

- For the file list and item list, The space between the name, and the note, has been greatly reduced. I wanted them to feel clearly seperate, but width is extremely previous in my program, and it's just super important that as much as possible is packed all together.

- Some code for entry groups. It doesn't fully work yet.
- Groups have a new tab in the general right bar.
- Groups can be renamed.
- Entrys can drop into groups.
- Entrys can drop to entrys inside groups.
- Entrys can drop from a group, to a entry outside of it.