### PR TITLE
BIG RECODE FOR GROUPS!

### DIFF
--- a/Commands (Tools, Events, Methods, etc)/CM_Saves.cs
+++ b/Commands (Tools, Events, Methods, etc)/CM_Saves.cs
@@ -300,14 +300,38 @@ namespace GameEditorStudio
                                         writer.WriteElementString("Name", column.ColumnName);
                                         writer.WriteElementString("Key", column.Key);
 
-
-                                        foreach (var entry in column.EntryList)
+                                        foreach (ItemBase itembase in column.ItemBaseList) 
                                         {
-                                            writer.WriteStartElement("Entry");                                            
+                                            if (itembase is Entry Ientry)
+                                            {
+                                                SaveAnEntry(Ientry);
+                                            }
+
+                                            if (itembase is Group group) 
+                                            {
+                                                writer.WriteStartElement("Group");
+                                                writer.WriteElementString("Name", group.GroupName);
+                                                writer.WriteElementString("Tooltip", group.GroupTooltip);
+                                                writer.WriteElementString("Key", group.Key);
+
+                                                foreach (Entry Gentry in group.EntryList)
+                                                {
+                                                    SaveAnEntry(Gentry);
+                                                }
+
+                                                writer.WriteEndElement(); //End Group
+                                            }
+
+                                            
+                                        }
+
+                                        void SaveAnEntry(Entry entry) 
+                                        {
+                                            writer.WriteStartElement("Entry");
                                             writer.WriteElementString("Name", entry.Name);
                                             writer.WriteElementString("Tooltip", entry.WorkshopTooltip);
                                             writer.WriteElementString("IsNameHidden", entry.IsNameHidden.ToString());
-                                            writer.WriteElementString("IsEntryHidden", entry.IsEntryHidden.ToString());  
+                                            writer.WriteElementString("IsEntryHidden", entry.IsEntryHidden.ToString());
                                             writer.WriteElementString("RowOffset", entry.RowOffset.ToString());
                                             writer.WriteElementString("Bytes", entry.Bytes.ToString());
                                             //writer.WriteElementString("Endianness", entry.Endianness.ToString());
@@ -329,8 +353,6 @@ namespace GameEditorStudio
                                             if (entry.NewSubType == Entry.EntrySubTypes.CheckBox)
                                             {
                                                 writer.WriteStartElement("CheckBox");
-                                                //writer.WriteElementString("TrueText", entry.EntryTypeCheckBox.TrueText.ToString());
-                                                //writer.WriteElementString("FalseText", entry.EntryTypeCheckBox.FalseText.ToString());
                                                 writer.WriteElementString("TrueValue", entry.EntryTypeCheckBox.TrueValue.ToString());
                                                 writer.WriteElementString("FalseValue", entry.EntryTypeCheckBox.FalseValue.ToString());
                                                 writer.WriteEndElement(); //End CheckBox 
@@ -341,29 +363,13 @@ namespace GameEditorStudio
                                             {
                                                 writer.WriteStartElement("BitFlag");
                                                 writer.WriteElementString("Flag1Name", entry.EntryTypeBitFlag.BitFlag1Name.ToString());
-                                                //writer.WriteElementString("Flag1CheckText", entry.EntryTypeBitFlag.BitFlag1CheckText.ToString());
-                                                //writer.WriteElementString("Flag1UncheckText", entry.EntryTypeBitFlag.BitFlag1UncheckText.ToString());
                                                 writer.WriteElementString("Flag2Name", entry.EntryTypeBitFlag.BitFlag2Name.ToString());
-                                                //writer.WriteElementString("Flag2CheckText", entry.EntryTypeBitFlag.BitFlag2CheckText.ToString());
-                                                //writer.WriteElementString("Flag2UncheckText", entry.EntryTypeBitFlag.BitFlag2UncheckText.ToString());
                                                 writer.WriteElementString("Flag3Name", entry.EntryTypeBitFlag.BitFlag3Name.ToString());
-                                                //writer.WriteElementString("Flag3CheckText", entry.EntryTypeBitFlag.BitFlag3CheckText.ToString());
-                                                //writer.WriteElementString("Flag3UncheckText", entry.EntryTypeBitFlag.BitFlag3UncheckText.ToString());
                                                 writer.WriteElementString("Flag4Name", entry.EntryTypeBitFlag.BitFlag4Name.ToString());
-                                                //writer.WriteElementString("Flag4CheckText", entry.EntryTypeBitFlag.BitFlag4CheckText.ToString());
-                                                //writer.WriteElementString("Flag4UncheckText", entry.EntryTypeBitFlag.BitFlag4UncheckText.ToString());
                                                 writer.WriteElementString("Flag5Name", entry.EntryTypeBitFlag.BitFlag5Name.ToString());
-                                                //writer.WriteElementString("Flag5CheckText", entry.EntryTypeBitFlag.BitFlag5CheckText.ToString());
-                                                //writer.WriteElementString("Flag5UncheckText", entry.EntryTypeBitFlag.BitFlag5UncheckText.ToString());
                                                 writer.WriteElementString("Flag6Name", entry.EntryTypeBitFlag.BitFlag6Name.ToString());
-                                                //writer.WriteElementString("Flag6CheckText", entry.EntryTypeBitFlag.BitFlag6CheckText.ToString());
-                                                //writer.WriteElementString("Flag6UncheckText", entry.EntryTypeBitFlag.BitFlag6UncheckText.ToString());
                                                 writer.WriteElementString("Flag7Name", entry.EntryTypeBitFlag.BitFlag7Name.ToString());
-                                                //writer.WriteElementString("Flag7CheckText", entry.EntryTypeBitFlag.BitFlag7CheckText.ToString());
-                                                //writer.WriteElementString("Flag7UncheckText", entry.EntryTypeBitFlag.BitFlag7UncheckText.ToString());
                                                 writer.WriteElementString("Flag8Name", entry.EntryTypeBitFlag.BitFlag8Name.ToString());
-                                                //writer.WriteElementString("Flag8CheckText", entry.EntryTypeBitFlag.BitFlag8CheckText.ToString());
-                                                //writer.WriteElementString("Flag8UncheckText", entry.EntryTypeBitFlag.BitFlag8UncheckText.ToString());
                                                 writer.WriteEndElement(); //End BitFlag    
                                             }
 
@@ -376,12 +382,12 @@ namespace GameEditorStudio
                                                 if (entry.EntryTypeMenu.MenuType == EntryTypeMenu.MenuTypes.List) { writer.WriteElementString("MenuType", "List"); }
                                                 if (entry.EntryTypeMenu.LinkType == EntryTypeMenu.LinkTypes.DataFile) { writer.WriteElementString("LinkType", "DataFile"); }
                                                 if (entry.EntryTypeMenu.LinkType == EntryTypeMenu.LinkTypes.TextFile) { writer.WriteElementString("LinkType", "TextFile"); }
-                                                if (entry.EntryTypeMenu.LinkType == EntryTypeMenu.LinkTypes.Editor) { writer.WriteElementString("LinkType", "Editor"); }                                                
+                                                if (entry.EntryTypeMenu.LinkType == EntryTypeMenu.LinkTypes.Editor) { writer.WriteElementString("LinkType", "Editor"); }
                                                 if (entry.EntryTypeMenu.LinkType == EntryTypeMenu.LinkTypes.Nothing) { writer.WriteElementString("LinkType", "Nothing"); }
 
-                                                                                             
 
-                                                if (entry.EntryTypeMenu.LinkType == EntryTypeMenu.LinkTypes.DataFile) 
+
+                                                if (entry.EntryTypeMenu.LinkType == EntryTypeMenu.LinkTypes.DataFile)
                                                 {
                                                     writer.WriteStartElement("FileData");
                                                     writer.WriteElementString("FirstNameID", entry.EntryTypeMenu.FirstNameID.ToString());
@@ -411,11 +417,11 @@ namespace GameEditorStudio
                                                         writer.WriteElementString("EditorName", entry.EntryTypeMenu.OldLinkedEditorName); //Yes we're saving the OLD Editor. This is NOT an axident!
                                                         writer.WriteElementString("EditorKey", entry.EntryTypeMenu.OldLinkedEditorKey);
                                                     }
-                                                    else 
+                                                    else
                                                     {
                                                         writer.WriteElementString("EditorName", entry.EntryTypeMenu.LinkedEditor.EditorName); //Only used to notify if a link to editor is missing. (The editor is missing)
                                                         writer.WriteElementString("EditorKey", entry.EntryTypeMenu.LinkedEditor.EditorKey);
-                                                    }                                                    
+                                                    }
                                                     //writer.WriteElementString("Start", entry.EntryTypeMenu.Start.ToString());
                                                     writer.WriteElementString("NameCount", entry.EntryTypeMenu.NameCount.ToString());
                                                     writer.WriteEndElement(); //End FileData
@@ -433,7 +439,7 @@ namespace GameEditorStudio
                                                     }
                                                     writer.WriteEndElement(); //End NameList
                                                 }
-                                                
+
                                                 writer.WriteEndElement(); //End Menu    
 
                                             }
@@ -446,6 +452,8 @@ namespace GameEditorStudio
 
                                             writer.WriteEndElement(); //End Entry
                                         }
+
+                                        
                                         writer.WriteEndElement(); //End Column
                                     }
                                     writer.WriteEndElement(); //End Category
@@ -525,39 +533,30 @@ namespace GameEditorStudio
                                 
                             }
 
+                            
+
                             foreach (Editor TheEditor in Database.GameEditors.Values) 
                             {
-                                foreach (Category TheCat in TheEditor.StandardEditorData.CategoryList) 
+                                foreach (Entry theEntry in TheEditor.StandardEditorData.MasterEntryList)
                                 {
-                                    foreach (Column TheColumn in TheCat.ColumnList) 
+                                    if (theEntry.NewSubType == Entry.EntrySubTypes.Menu)
                                     {
-                                        foreach (Entry theEntry in TheColumn.EntryList) 
+                                        if (theEntry.EntryTypeMenu.LinkType == EntryTypeMenu.LinkTypes.DataFile || theEntry.EntryTypeMenu.LinkType == EntryTypeMenu.LinkTypes.TextFile)
                                         {
-                                            if (theEntry.NewSubType == Entry.EntrySubTypes.Menu) 
+                                            if (theEntry.EntryTypeMenu.GameFile != null)
                                             {
-                                                if (theEntry.EntryTypeMenu.LinkType == EntryTypeMenu.LinkTypes.DataFile || theEntry.EntryTypeMenu.LinkType == EntryTypeMenu.LinkTypes.TextFile) 
+                                                GameFile AFile = theEntry.EntryTypeMenu.GameFile;
+                                                if (!SomeGameFiles.Contains(AFile))
                                                 {
-                                                    if (theEntry.EntryTypeMenu.GameFile != null) 
-                                                    {
-                                                        GameFile AFile = theEntry.EntryTypeMenu.GameFile;
-                                                        if (!SomeGameFiles.Contains(AFile))
-                                                        {
-                                                            SomeGameFiles.Add(AFile);
-                                                        }
-                                                    }
+                                                    SomeGameFiles.Add(AFile);
                                                 }
-
-                                                //if (theEntry.EntryTypeMenu.LinkType == EntryTypeMenu.LinkTypes.Editor)
-                                                //{
-                                                    
-                                                //}
-
-
-
                                             }
                                         }
+
+
                                     }
                                 }
+                                
                             }
 
                             foreach (GameFile AGameFile in SomeGameFiles)

--- a/Databases/StandardEditorData.cs
+++ b/Databases/StandardEditorData.cs
@@ -63,7 +63,7 @@ namespace GameEditorStudio
         public string CategoryName { get; set; } = "New Category"; //XML the name of a row.
         public Border CatBorder { get; set; } = new();
         public DockPanel CategoryDockPanel { get; set; } = new();
-        public List<Column>? ColumnList { get; set; } = new();
+        public List<Column> ColumnList { get; set; } = new();
         public Label CategoryLabel { get; set; }
         public StandardEditorData SWData { get; set; }
 
@@ -133,9 +133,7 @@ namespace GameEditorStudio
     {
         public string ColumnName { get; set; } = "New Column"; //XML The name of a column.
         public DockPanel? ColumnPanel { get; set; }
-        public List<Entry>? EntryList { get; set; } = new();
-
-        public List<CItem>? MasterList { get; set; } = new();
+        public List<ItemBase> ItemBaseList { get; set; } = new();
         public Label ColumnLabel { get; set; }
         public Category ColumnRow { get; set; }
 
@@ -144,9 +142,9 @@ namespace GameEditorStudio
         public string Key { get; set; } = LibraryMan.GenerateKey(); //Unused, Only exists incase of future features. 
     }
 
-    public abstract class CItem { }
+    public abstract class ItemBase { } //A group or an entry. Groups can hold entrys, and also look cool and are a way to sort stuff. 
 
-    public class Group : CItem //A way to group entries together, like a folder.
+    public class Group : ItemBase //A way to group entries together, like a folder.
     {
         public string GroupName { get; set; } = "New Group"; //XML The name of a column.
         public string GroupTooltip { get; set; } = "";
@@ -159,7 +157,7 @@ namespace GameEditorStudio
     }
     
 
-    public class Entry : CItem
+    public class Entry : ItemBase
     {
         public string Name { get; set; } = "";  //XML //The Name / Label an entry Gets. Later, it will default to "???"  
         public string WorkshopTooltip { get; set; } = ""; //XML

--- a/Editors/Standard/LoadStandardEditor.cs
+++ b/Editors/Standard/LoadStandardEditor.cs
@@ -143,7 +143,7 @@ namespace GameEditorStudio
                 //There exist some more as well, but those aren't strictly necessary to a new entry.
 
                 Entry EntryClass = new();
-                ColumnClass.EntryList.Add(EntryClass);
+                ColumnClass.ItemBaseList.Add(EntryClass);
                 EditorClass.StandardEditorData.MasterEntryList.Add(EntryClass); 
 
                 EntryClass.DataTableRowSize = Int32.Parse(Maker.TextBoxDataTableRowSize.Text);
@@ -298,29 +298,51 @@ namespace GameEditorStudio
 
             foreach (XElement Xrow in xml.Descendants("Category"))
             {
-                string rowName = Xrow.Element("Name")?.Value;
-                string rowKey = Xrow.Element("Key")?.Value;
-                //int rowOrder = int.Parse(row.Element("RowOrder")?.Value);
-                Category CategoryClass = new Category { CategoryName = rowName, Key = rowKey }; //, RowOrder = rowOrder
+                Category CategoryClass = new();
+                CategoryClass.CategoryName = Xrow.Element("Name")?.Value;
+                CategoryClass.Key = Xrow.Element("Key")?.Value;
                 CategoryClass.SWData = EditorClass.StandardEditorData;
 
                 EditorClass.StandardEditorData.CategoryList.Add(CategoryClass);
 
                 foreach (XElement Xcolumn in Xrow.Descendants("Column"))
-                {
-                    string columnName = Xcolumn.Element("Name")?.Value;
-                    string columnKey = Xcolumn.Element("Key")?.Value;
-                    Column ColumnClass = new Column { ColumnName = columnName, Key = columnKey }; //, ColumnOrder = columnOrder
+                {                    
+                    Column ColumnClass = new(); 
+                    ColumnClass.ColumnName = Xcolumn.Element("Name")?.Value;
+                    ColumnClass.Key = Xcolumn.Element("Key")?.Value;
 
-
-                    CategoryClass.ColumnList ??= new List<Column>(); // Add the  object to the List
                     CategoryClass.ColumnList.Add(ColumnClass);
-                    ColumnClass.EntryList ??= new List<Entry>(); // Add the  object to the List
-                    foreach (XElement Xentry in Xcolumn.Descendants("Entry"))
-                    {
 
+                    foreach (XElement XCitem in Xcolumn.Elements())
+                    {
+                        if (XCitem.Name == "Group")
+                        {
+                            Group GroupClass = new();
+                            GroupClass.GroupColumn = ColumnClass;
+                            ColumnClass.ItemBaseList.Add(GroupClass);
+                            GroupClass.GroupName = XCitem.Element("Name")?.Value;
+                            GroupClass.Key = XCitem.Element("Key")?.Value;
+                            GroupClass.GroupTooltip = XCitem.Element("Tooltip")?.Value;
+
+                            foreach (XElement Xentry in XCitem.Elements("Entry"))
+                            {
+                                LoadEntry(Xentry, GroupClass);
+                            }
+                        }
+                        else if (XCitem.Name == "Entry")
+                        {
+                            LoadEntry(XCitem, null); // Pass the XElement if needed
+                        }
+                    }
+                        
+
+                    void LoadEntry(XElement Xentry, Group MyGroup) 
+                    {
                         Entry EntryClass = new();
                         EditorClass.StandardEditorData.MasterEntryList.Add(EntryClass);
+                        if (MyGroup != null) { MyGroup.EntryList.Add(EntryClass); } //Group adding.
+                        if (MyGroup == null) { ColumnClass.ItemBaseList.Add(EntryClass); } //Column adding.
+                        
 
                         EntryClass.Name = Xentry.Element("Name")?.Value;
                         EntryClass.WorkshopTooltip = Xentry.Element("Tooltip")?.Value;
@@ -400,23 +422,6 @@ namespace GameEditorStudio
                                 EntryClass.EntryTypeBitFlag.BitFlag6Name = XBitFlag.Element("Flag6Name")?.Value;
                                 EntryClass.EntryTypeBitFlag.BitFlag7Name = XBitFlag.Element("Flag7Name")?.Value;
                                 EntryClass.EntryTypeBitFlag.BitFlag8Name = XBitFlag.Element("Flag8Name")?.Value;
-                                //EntryClass.EntryTypeBitFlag.BitFlag1CheckText = XBitFlag.Element("Flag1CheckText")?.Value;
-                                //EntryClass.EntryTypeBitFlag.BitFlag2CheckText = XBitFlag.Element("Flag2CheckText")?.Value;
-                                //EntryClass.EntryTypeBitFlag.BitFlag3CheckText = XBitFlag.Element("Flag3CheckText")?.Value;
-                                //EntryClass.EntryTypeBitFlag.BitFlag4CheckText = XBitFlag.Element("Flag4CheckText")?.Value;
-                                //EntryClass.EntryTypeBitFlag.BitFlag5CheckText = XBitFlag.Element("Flag5CheckText")?.Value;
-                                //EntryClass.EntryTypeBitFlag.BitFlag6CheckText = XBitFlag.Element("Flag6CheckText")?.Value;
-                                //EntryClass.EntryTypeBitFlag.BitFlag7CheckText = XBitFlag.Element("Flag7CheckText")?.Value;
-                                //EntryClass.EntryTypeBitFlag.BitFlag8CheckText = XBitFlag.Element("Flag8CheckText")?.Value;
-                                //EntryClass.EntryTypeBitFlag.BitFlag1UncheckText = XBitFlag.Element("Flag1UncheckText")?.Value;
-                                //EntryClass.EntryTypeBitFlag.BitFlag2UncheckText = XBitFlag.Element("Flag2UncheckText")?.Value;
-                                //EntryClass.EntryTypeBitFlag.BitFlag3UncheckText = XBitFlag.Element("Flag3UncheckText")?.Value;
-                                //EntryClass.EntryTypeBitFlag.BitFlag4UncheckText = XBitFlag.Element("Flag4UncheckText")?.Value;
-                                //EntryClass.EntryTypeBitFlag.BitFlag5UncheckText = XBitFlag.Element("Flag5UncheckText")?.Value;
-                                //EntryClass.EntryTypeBitFlag.BitFlag6UncheckText = XBitFlag.Element("Flag6UncheckText")?.Value;
-                                //EntryClass.EntryTypeBitFlag.BitFlag7UncheckText = XBitFlag.Element("Flag7UncheckText")?.Value;
-                                //EntryClass.EntryTypeBitFlag.BitFlag8UncheckText = XBitFlag.Element("Flag8UncheckText")?.Value;
-
                             }
                         }
 
@@ -495,7 +500,7 @@ namespace GameEditorStudio
                                             "You can fix this IF you know what your doing by changing that entrys linked text data. (It's probably a menu type entry), "
 
                                             );
-                                        
+
                                     }
 
                                     //if (EntryClass.EntryTypeMenu.LinkedEditor == null)
@@ -537,8 +542,10 @@ namespace GameEditorStudio
 
 
 
-                        ColumnClass.EntryList.Add(EntryClass);
-                    }
+                        
+                    }//End of LoadEntry method
+
+                    
                 }
                 
 

--- a/Main/ExportToGoogleSheets.cs
+++ b/Main/ExportToGoogleSheets.cs
@@ -49,24 +49,16 @@ namespace GameEditorStudio
 
             for (int ColumnInRow1 = 0; ColumnInRow1 != Columns; ColumnInRow1++) //Setting up the first row, to get Column / Entry names.
             {
-                foreach (var cat in EditorClass.StandardEditorData.CategoryList)
+                foreach (Entry entry in EditorClass.StandardEditorData.MasterEntryList)
                 {
-                    foreach (var column in cat.ColumnList)
+                    if (entry.RowOffset == ColumnInRow1)
                     {
-                        foreach (var entry in column.EntryList)
-                        {
-                            if (entry.RowOffset == ColumnInRow1) 
-                            {
-                                EditorDataDecimalCurrent = EditorDataDecimalCurrent + entry.Name + ",";
-                                EditorDataHexCurrent = EditorDataHexCurrent + entry.Name + ",";
-                                EditorDataDecimalOrigonal = EditorDataDecimalOrigonal + entry.Name + ",";
-                                EditorDataHexOrigonal = EditorDataHexOrigonal + entry.Name + ",";
-                            }
-
-                        }
+                        EditorDataDecimalCurrent = EditorDataDecimalCurrent + entry.Name + ",";
+                        EditorDataHexCurrent = EditorDataHexCurrent + entry.Name + ",";
+                        EditorDataDecimalOrigonal = EditorDataDecimalOrigonal + entry.Name + ",";
+                        EditorDataHexOrigonal = EditorDataHexOrigonal + entry.Name + ",";
                     }
                 }
-
             }
             EditorDataDecimalCurrent = EditorDataDecimalCurrent + "\r\n";
             EditorDataHexCurrent = EditorDataHexCurrent + "\r\n";

--- a/User Controls/TheLeftBar.xaml.cs
+++ b/User Controls/TheLeftBar.xaml.cs
@@ -460,22 +460,18 @@ namespace GameEditorStudio
                 }
             }
 
-            foreach (var TheEditor in Database.GameEditors)  //This code chunk is my ultra lazy way to update every Dropdown & List across all editors the moment any item changes its name incase that data is used in them.
+            //This code chunk is my ultra lazy way to update every Dropdown & List across all editors the moment any item changes its name incase that data is used in them.
+            foreach (var TheEditor in Database.GameEditors.Values)  
             {
-                foreach (var Cats in TheEditor.Value.StandardEditorData.CategoryList)
+                foreach (Entry entry in TheEditor.StandardEditorData.MasterEntryList) 
                 {
-                    foreach (var Grops in Cats.ColumnList)
+                    if (entry.NewSubType == EntrySubTypes.Menu)
                     {
-                        foreach (var EndEntry in Grops.EntryList)
-                        {
-                            if (EndEntry.NewSubType == EntrySubTypes.Menu)
-                            {
 
-                                Database.EntryManager.EntryChange(Database, EntrySubTypes.Menu, TheWorkshop, EndEntry);
-                            }
-                        }
+                        Database.EntryManager.EntryChange(Database, EntrySubTypes.Menu, TheWorkshop, entry);
                     }
                 }
+                
             }
 
 


### PR DESCRIPTION
- EntryList in a column is GONE, it's a ItemBaseList now, and ItemBase in a abstract of both Entrys and Groups.

- Removed many uses of nested foreach code to get to entrys, for the new editor MasterEntryList.

- I think i fixed an old bug involving showing or hiding entrys, related to if they represented text in use or not.
- cleaned up some LoadStandardEditor code.

- lots of code changes for groups, all over.
- Groups save and load to/from xml.
- Group tooltip and name box fully work.
- Honestly a lot of group code. Groups are actually functional now. HUZZAH. I DID IT IN TIME FOR RELEASE! OMG!