### PR TITLE
- Fixed category tooltips not showing when hovered. (caused by the ne…

### DIFF
--- a/Commands (Tools, Events, Methods, etc)/CM_Saves.cs
+++ b/Commands (Tools, Events, Methods, etc)/CM_Saves.cs
@@ -337,8 +337,12 @@ namespace GameEditorStudio
                                             writer.WriteElementString("Bytes", entry.Bytes.ToString());
                                             //writer.WriteElementString("Endianness", entry.Endianness.ToString());
 
-                                            if (entry.Endianness == "1" || entry.Endianness == "2L" || entry.Endianness == "4L") { writer.WriteElementString("Endianness", "Little"); }
+                                            if (entry.Endianness == "1" || entry.Endianness == "2L" || entry.Endianness == "4L")
+                                            { writer.WriteElementString("Endianness", "Little"); }
                                             else { writer.WriteElementString("Endianness", "Big"); }
+                                            if (entry.Bytes == 0) 
+                                            { writer.WriteElementString("IsMerged", "True"); }
+                                            else { writer.WriteElementString("IsMerged", "False"); }
 
                                             //writer.WriteElementString("TypeX", entry.SubType);
 

--- a/Databases/StandardEditorData.cs
+++ b/Databases/StandardEditorData.cs
@@ -64,6 +64,7 @@ namespace GameEditorStudio
         public string Tooltip { get; set; } = "";
         public Border CatBorder { get; set; } = new();
         public DockPanel CategoryDockPanel { get; set; } = new();
+        public Grid TooltipGrid { get; set; } = new(); 
         public Border CategoryUnderline { get; set; } = new(); //for tooltips
         public List<Column> ColumnList { get; set; } = new();
         public Label CategoryLabel { get; set; }
@@ -167,6 +168,7 @@ namespace GameEditorStudio
         public bool IsNameHidden { get; set; } = false;  //XML //Yes or No, Defaults to Yes
         public bool IsEntryHidden { get; set; } = false;  //XML  -Enabled or Disabled (AutoDisabled?)//Decides If entry can save to Memory File. Occurs when the byte is also in use by the NameTable or any ExtraTables.  
         public bool IsTextInUse { get; set; } = false; //Not XML //if true, this entry actually represents name or description text, and is basically disabled / hidden. 
+        public bool IsMerged { get; set; } = false; //Not saved to XML, but a value like this DOES save to XML. Be VERY careful on later deciding to actually use this. 
         public EntrySubTypes NewSubType { get; set; } = EntrySubTypes.NumberBox;
         public enum EntrySubTypes { NumberBox, CheckBox, BitFlag, Menu}
         //public int ByteStarting { get; set; } //This number is how many bytes from the start of a file the editor begins. Each entry keeps track of it's own, because some editors have more then 1 file.
@@ -191,7 +193,7 @@ namespace GameEditorStudio
 
         public string EntryByteDecimal { get; set; } //NOT XML  //Needed to deal with the true value of a checkbox or bitflag.  //THIS SHOULD ALWAYS READ AS A POSITIVE NUMBER, IF ITS NEGATIVE IT'S A BUG AND I NEED TO FIX IT! 
 
-        public Border EntryBorder { get; set; } //The border around a entry,
+        public Border EntryBorder { get; set; } = new(); //The border around a entry,
         public DockPanel? EntryDockPanel { get; set; } //The entrys Grid, visable to the used, and contains lots of information.
         public Label Symbology { get; set; }
         public Label EntryPrefix { get; set; }   //Used to show the byte offset to a user. Useful when creating an editor, and you don't know what things do yet.

--- a/Editors/Standard/GenerateStandardEditor.cs
+++ b/Editors/Standard/GenerateStandardEditor.cs
@@ -369,10 +369,10 @@ namespace GameEditorStudio
             EditorPanel.Children.Add(ScrollViewer);
             ScrollViewer.HorizontalScrollBarVisibility = ScrollBarVisibility.Auto;
 
-            //ScrollViewer.PreviewMouseWheel += ScrollViewer_PreviewMouseWheel;
-            //ScrollViewer.PreviewMouseDown += ScrollViewer_PreviewMouseDown;
-            //ScrollViewer.PreviewMouseUp += ScrollViewer_PreviewMouseUp;
-            //ScrollViewer.PreviewMouseMove += ScrollViewer_PreviewMouseMove;
+            ScrollViewer.PreviewMouseWheel += ScrollViewer_PreviewMouseWheel;
+            ScrollViewer.PreviewMouseDown += ScrollViewer_PreviewMouseDown;
+            ScrollViewer.PreviewMouseUp += ScrollViewer_PreviewMouseUp;
+            ScrollViewer.PreviewMouseMove += ScrollViewer_PreviewMouseMove;
 
 
 
@@ -544,6 +544,7 @@ namespace GameEditorStudio
             //RowPanel.Children.Add(Header);
 
             Grid LabelGrid = new();
+            CatClass.TooltipGrid = LabelGrid;
             Header.Children.Add(LabelGrid);
 
             Label CatLabel = new Label();
@@ -1082,7 +1083,7 @@ namespace GameEditorStudio
 
             //end of temp block
 
-            Border Border = new();
+            Border Border = EntryClass.EntryBorder;
             Border.BorderThickness = new Thickness(2);
             Border.CornerRadius = new CornerRadius(3);
             DockPanel.SetDock(Border, Dock.Top);
@@ -1412,11 +1413,8 @@ namespace GameEditorStudio
             if (GroupClass == null) { ColumnClass.ColumnPanel.Children.Add(Border); }
             if (GroupClass != null) { GroupClass.GroupPanel.Children.Add(Border); }
             Border.Child = EntryDockPanel;
-            EntryClass.EntryDockPanel = new();
             EntryClass.EntryDockPanel = EntryDockPanel;
-            EntryClass.EntryBorder = new();
-            EntryClass.EntryBorder = Border;
-            if (EntryClass.Bytes == 0) { EntryClass.EntryBorder.Visibility = Visibility.Collapsed; }
+            
 
             Label PrefixEID = new Label(); //Entry ID Prefix. 
             //Prefix.Height = 30;
@@ -1492,7 +1490,10 @@ namespace GameEditorStudio
                 TheWorkshop.UpdateSymbology(EntryClass);
             }
 
-
+            if (EntryClass.Bytes == 0)
+            {
+                Border.Visibility = Visibility.Collapsed;
+            }
 
         }
 

--- a/Editors/Standard/LoadStandardEditor.cs
+++ b/Editors/Standard/LoadStandardEditor.cs
@@ -349,6 +349,7 @@ namespace GameEditorStudio
                         EntryClass.WorkshopTooltip = Xentry.Element("Tooltip")?.Value;
                         EntryClass.IsNameHidden = Convert.ToBoolean(Xentry.Element("IsNameHidden")?.Value);
                         EntryClass.IsEntryHidden = Convert.ToBoolean(Xentry.Element("IsEntryHidden")?.Value);
+                        EntryClass.IsMerged = Convert.ToBoolean(Xentry.Element("IsMerged")?.Value);
                         EntryClass.TableKey = Xentry.Element("TableKey")?.Value;
                         EntryClass.DataTableRowSize = Int32.Parse(Xentry.Element("RowSize")?.Value);
                         EntryClass.RowOffset = Int32.Parse(Xentry.Element("RowOffset")?.Value);

--- a/Main/LibraryMan.cs
+++ b/Main/LibraryMan.cs
@@ -18,7 +18,7 @@ namespace GameEditorStudio
     {        
         
         public static string VersionDate { get; set; } = "June 13 2025";
-        public static Version VersionNumber { get; set; } = new Version(0, 1, 0, 0); //Version Numbers (in order) are Major.Minor.Build.Revision
+        public static Version VersionNumber { get; set; } = new Version(0, 1, 1, 0); //Version Numbers (in order) are Major.Minor.Build.Revision
         //Major is big releases.
         //Minor is new features / content.
         //Build is for Bugfixes or small changes.

--- a/Windows/Workshop.xaml.cs
+++ b/Windows/Workshop.xaml.cs
@@ -495,7 +495,7 @@ namespace GameEditorStudio
 
                     if (Properties.Settings.Default.ShowHiddenEntrys == false)
                     {
-                        if (entry.IsEntryHidden == true || entry.IsTextInUse == true)
+                        if (entry.IsEntryHidden == true || entry.IsTextInUse == true || entry.Bytes == 0)
                         {
                             entry.EntryBorder.Visibility = Visibility.Collapsed;
                         }
@@ -509,7 +509,7 @@ namespace GameEditorStudio
                             entry.EntryRow.CatBorder.Visibility = Visibility.Visible;
                         }
                     }
-                    else if (Properties.Settings.Default.ShowHiddenEntrys == true)
+                    else if (Properties.Settings.Default.ShowHiddenEntrys == true && entry.Bytes != 0)
                     {
                         entry.EntryBorder.Visibility = Visibility.Visible;
                         entry.EntryColumn.ColumnPanel.Visibility = Visibility.Visible;                        
@@ -1131,13 +1131,15 @@ namespace GameEditorStudio
                 itemInfo.IsChild = true;
             }
 
-            ItemNameBuilder(FolderItem); //Created the Header text as a TextBlockItem
+            
             TreeView.Items.Insert(selectedIndex, FolderItem);
             FolderItem.Items.Add(TreeViewItem);
+            ItemNameBuilder(FolderItem); //Created the Header text as a TextBlockItem
 
 
+            FolderItem.IsExpanded = true;
             TreeViewSelectionEnabled = true;
-
+            TreeViewItem.IsSelected = true;
 
             ContextMenu contextMenu = new ContextMenu();
             
@@ -1183,12 +1185,13 @@ namespace GameEditorStudio
             {
                 Run RunFolder = new Run();
                 RunFolder.Foreground = Brushes.Yellow;
-                RunFolder.Text = "📁 ";
+                RunFolder.Text = "📁";
                 TextBlockItem.Inlines.Add(RunFolder);
 
                 Run RunFolderCount = new Run();
                 RunFolderCount.Text = "(" + TreeItem.Items.Count.ToString() + ") ";
                 TextBlockItem.Inlines.Add(RunFolderCount);
+                                
             }
 
             Run RunMain = new Run();
@@ -1374,11 +1377,13 @@ namespace GameEditorStudio
             CategoryClass.Tooltip = PropertiesRowTooltipBox.Text;            
             if (PropertiesRowTooltipBox.Text == "")
             {
+                CategoryClass.TooltipGrid.ToolTip = null;
                 CategoryClass.CategoryLabel.ToolTip = null;
                 CategoryClass.CategoryUnderline.Visibility = Visibility.Collapsed;
             }
             else 
             {
+                CategoryClass.TooltipGrid.ToolTip = CategoryClass.Tooltip;
                 CategoryClass.CategoryLabel.ToolTip = CategoryClass.Tooltip;
                 CategoryClass.CategoryUnderline.Visibility = Visibility.Visible;
             }


### PR DESCRIPTION
…w tooltip underline last time)

- Fixed merged entrys not being hidden (Oops, this was caused by my changes and overuser of the decorations system)

- Left bar items, when turned info folders, now immedietly reselect the item, and also the folder now immedietly shows the correct item count (of 1).
- Left bar items can now be moved in bulk by holding shift! This should make it way easier to deal with very large item lists. And also make it way easier to folder them!

- Bumped release number upto 0.1.1