### PR TITLE
Cross Reference QoL & Symbology improvements

### DIFF
--- a/Editors/Standard/StandardEditorMethods.cs
+++ b/Editors/Standard/StandardEditorMethods.cs
@@ -278,11 +278,8 @@ namespace GameEditorStudio
                 }
             }
 
-            if (TheWorkshop.TheCrossReference != null) 
-            {
-                TheWorkshop.TheCrossReference.FillLearnBox(EditorClass, EntryClass);
-            }
-            
+                        
+
         }
 
         public static void UpdateEntryName(Entry EntryClass) 

--- a/Main/EntryManager.cs
+++ b/Main/EntryManager.cs
@@ -1865,11 +1865,10 @@ namespace GameEditorStudio
             /////////////////////Data Analyzer/////////////////////
             //TheWorkshop.PropertiesEntry1Byte.Text = EditorClass.StandardEditorData.FileDataTable.FileBytes[EditorClass.StandardEditorData.DataTableStart + (EditorClass.StandardEditorData.TableRowIndex * EntryClass.DataTableRowSize) + EntryClass.RowOffset].ToString("D");
             if (TheWorkshop.IsPreviewMode == true) { return; }
-            TheWorkshop.PropertiesEntry1Byte.Text = EntryClass.EntryByteDecimal;            
+            
+            
+            TheWorkshop.PropertiesEntry1Byte.Text = EditorClass.StandardEditorData.FileDataTable.FileBytes[EditorClass.StandardEditorData.DataTableStart + (EditorClass.StandardEditorData.TableRowIndex * EntryClass.DataTableRowSize) + EntryClass.RowOffset].ToString("D");
             TheWorkshop.PropertiesEntryHex1Byte.Text = EditorClass.StandardEditorData.FileDataTable.FileBytes[EditorClass.StandardEditorData.DataTableStart + (EditorClass.StandardEditorData.TableRowIndex * EntryClass.DataTableRowSize) + EntryClass.RowOffset].ToString("X2");
-
-
-
 
             try
             {
@@ -1907,6 +1906,71 @@ namespace GameEditorStudio
                 TheWorkshop.PropertiesEntryHex4ByteB.Text = "END OF FILE";
                 TheWorkshop.PropertiesEntry4ByteL.Text = "END OF FILE";
                 TheWorkshop.PropertiesEntryHex4ByteL.Text = "END OF FILE";
+            }
+
+
+            //Starting here is for attempting to read possible negative values. 
+            // === 1 Byte (Signed) ===
+            try
+            {
+                sbyte signedByte = (sbyte)EditorClass.StandardEditorData.FileDataTable.FileBytes[
+                    EditorClass.StandardEditorData.DataTableStart +
+                    (EditorClass.StandardEditorData.TableRowIndex * EntryClass.DataTableRowSize) +
+                    EntryClass.RowOffset];
+                TheWorkshop.PropertiesEntry1ByteNegative.Text = signedByte < 0 ? signedByte.ToString("D") : "";
+            }
+            catch
+            {
+                TheWorkshop.PropertiesEntry1ByteNegative.Text = "END OF FILE";
+            }
+
+            // === 2 Byte (Signed) ===
+            try
+            {
+                int offset2 = EditorClass.StandardEditorData.DataTableStart +
+                              (EditorClass.StandardEditorData.TableRowIndex * EntryClass.DataTableRowSize) +
+                              EntryClass.RowOffset;
+
+                short s2B = BitConverter.ToInt16(EditorClass.StandardEditorData.FileDataTable.FileBytes, offset2);
+                TheWorkshop.PropertiesEntry2ByteBNegative.Text = s2B < 0 ? s2B.ToString("D") : "";
+
+                byte[] signedBytes2L = EditorClass.StandardEditorData.FileDataTable.FileBytes
+                    .Skip(offset2).Take(2).ToArray();
+                Array.Reverse(signedBytes2L);
+                short swappedS2L = BitConverter.ToInt16(signedBytes2L, 0);
+                TheWorkshop.PropertiesEntry2ByteLNegative.Text = swappedS2L < 0 ? swappedS2L.ToString("D") : "";
+            }
+            catch
+            {
+                TheWorkshop.PropertiesEntry2ByteBNegative.Text = "END OF FILE";
+                TheWorkshop.PropertiesEntry2ByteLNegative.Text = "END OF FILE";
+            }
+
+            // === 4 Byte (Signed) ===
+            try
+            {
+                int offset4 = EditorClass.StandardEditorData.DataTableStart +
+                              (EditorClass.StandardEditorData.TableRowIndex * EntryClass.DataTableRowSize) +
+                              EntryClass.RowOffset;
+
+                int s4B = BitConverter.ToInt32(EditorClass.StandardEditorData.FileDataTable.FileBytes, offset4);
+                TheWorkshop.PropertiesEntry4ByteBNegative.Text = s4B < 0 ? s4B.ToString("D") : "";
+
+                byte[] signedBytes4L = EditorClass.StandardEditorData.FileDataTable.FileBytes
+                    .Skip(offset4).Take(4).ToArray();
+                Array.Reverse(signedBytes4L);
+                int swappedS4L = BitConverter.ToInt32(signedBytes4L, 0);
+                TheWorkshop.PropertiesEntry4ByteLNegative.Text = swappedS4L < 0 ? swappedS4L.ToString("D") : "";
+            }
+            catch
+            {
+                TheWorkshop.PropertiesEntry4ByteBNegative.Text = "END OF FILE";
+                TheWorkshop.PropertiesEntry4ByteLNegative.Text = "END OF FILE";
+            }
+
+            if (TheWorkshop.TheCrossReference != null)
+            {
+                TheWorkshop.TheCrossReference.FillLearnBox(EditorClass, EntryClass);
             }
         }
 

--- a/Windows/Workshop.xaml
+++ b/Windows/Workshop.xaml
@@ -288,7 +288,7 @@
                                                             <!-- Row 2 -->
                                                             <Label Content="Name" Grid.Row="0" Grid.Column="1" Margin="0"/>
                                                             <TextBox x:Name="PropertiesRowNameBox" Grid.Row="0" Grid.Column="2" Margin="3" Text="New Category" TextWrapping="Wrap"  KeyDown="PropertiesRowNameBox_KeyDownEnter"/>
-                                                            
+
                                                             <Label Content="Tooltip" Grid.Row="1" Grid.Column="1" Margin="0"/>
                                                             <TextBox x:Name="PropertiesRowTooltipBox" Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="2" MinHeight="100" Margin="3" TextWrapping="Wrap"  TextChanged="PropertiesRowTooltipBox_TextChanged"/>
                                                         </Grid>
@@ -419,12 +419,14 @@
                                             </ComboBox>-->
 
                                                             <Label Content="Byte Size" Grid.Row="4" Grid.Column="1" Margin="0"/>
+                                                            <Border Grid.Row="4" Grid.Column="1" Margin="3,0,24,3" BorderThickness="0,0,0,2" BorderBrush="#FFA4A4A4" ToolTip="Big Endian: 00 on left (0014, 002B). &#xA;Little Endian: 00 on right (1400, 2B00).&#xA;   &#xA;Most consoles use Big Endian."/>
                                                             <ComboBox x:Name="PropertiesEntryByteSizeComboBox" Grid.Row="4" Grid.Column="2" Margin="3" DropDownClosed="PropertiesEntryByteSizeComboBox_DropDownClosed" >
                                                                 <ComboBoxItem Content="1 Byte"/>
                                                                 <ComboBoxItem Content="2 Bytes Little Endian"/>
                                                                 <ComboBoxItem Content="4 Bytes Little Endian"/>
                                                                 <ComboBoxItem Content="2 Bytes Big Endian"/>
                                                                 <ComboBoxItem Content="4 Bytes Big Endian"/>
+                                                                
                                                             </ComboBox>
 
                                                             <Label Content="Entry Type" Grid.Row="5" Grid.Column="1" Margin="0"/>
@@ -518,30 +520,35 @@
 
                                                 <Border DockPanel.Dock="Top" Margin="0,0,0,0">
                                                     <DockPanel>
-                                                        <DockPanel Style="{DynamicResource HeaderDock}" DockPanel.Dock="Top"  >
-                                                            <Label Content="Hex Info" FontWeight="Bold" />
+                                                        <DockPanel Style="{DynamicResource HeaderDock}" DockPanel.Dock="Top" LastChildFill="False" >
+                                                            <Label Content="Hex Info" FontWeight="Bold"/>
+                                                            <Border Margin="-100,0,0,4" BorderThickness="0,0,0,2" Width="90" BorderBrush="#FFB7B7B7" ToolTip="Big Endian: 00 on left (0014, 002B). &#xA;Little Endian: 00 on right (1400, 2B00).&#xA;   &#xA;Most consoles use Big Endian."/>
                                                         </DockPanel>
                                                         <Grid DockPanel.Dock="Top">
-                                                            <Label Content="Decimal" HorizontalAlignment="Left" Margin="50,0,0,0" VerticalAlignment="Top"/>
-                                                            <Label Content="Hex" HorizontalAlignment="Left" Margin="184,0,0,0" VerticalAlignment="Top"/>
-
+                                                            <Label Content="Decimal" HorizontalAlignment="Left" Margin="50,-1,0,0" VerticalAlignment="Top"/>
+                                                            <Label Content="Hex" HorizontalAlignment="Left" Margin="178,-1,0,0" VerticalAlignment="Top"/>
+                                                            <Label Content="D Negatives" HorizontalAlignment="Left" Margin="259,-2,0,0" VerticalAlignment="Top"/>
 
                                                             <Label Content="1" HorizontalAlignment="Left" Margin="4,24,0,0" VerticalAlignment="Top"/>
-                                                            <Label Content="2B" HorizontalAlignment="Left" Margin="4,115,0,0" VerticalAlignment="Top"/>
-                                                            <Label Content="2L" HorizontalAlignment="Left" Margin="4,55,0,0" VerticalAlignment="Top"/>
-                                                            <Label Content="4B" HorizontalAlignment="Left" Margin="4,141,0,0" VerticalAlignment="Top"/>
-                                                            <Label Content="4L" HorizontalAlignment="Left" Margin="4,84,0,0" VerticalAlignment="Top"/>
+                                                            <Label Content="2B" HorizontalAlignment="Left" Margin="4,56,0,0" VerticalAlignment="Top"/>
+                                                            <Label Content="2L" HorizontalAlignment="Left" Margin="4,115,0,0" VerticalAlignment="Top"/>
+                                                            <Label Content="4B" HorizontalAlignment="Left" Margin="4,84,0,0" VerticalAlignment="Top"/>
+                                                            <Label Content="4L" HorizontalAlignment="Left" Margin="4,145,0,0" VerticalAlignment="Top"/>
                                                             <TextBox x:Name="PropertiesEntry1Byte" HorizontalAlignment="Left" Margin="34,28,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="111"/>
-                                                            <TextBox x:Name="PropertiesEntry2ByteB" HorizontalAlignment="Left" Margin="34,117,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="111"/>
-                                                            <TextBox x:Name="PropertiesEntry2ByteL" HorizontalAlignment="Left" Margin="34,58,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="111"/>
-                                                            <TextBox x:Name="PropertiesEntry4ByteB" HorizontalAlignment="Left" Margin="34,146,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="111"/>
-                                                            <TextBox x:Name="PropertiesEntry4ByteL" HorizontalAlignment="Left" Margin="34,88,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="111"/>
-                                                            <TextBox x:Name="PropertiesEntryHex1Byte" HorizontalAlignment="Left" Margin="149,28,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="96"/>
-                                                            <TextBox x:Name="PropertiesEntryHex2ByteB" HorizontalAlignment="Left" Margin="149,117,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="96"/>
-                                                            <TextBox x:Name="PropertiesEntryHex2ByteL" HorizontalAlignment="Left" Margin="149,58,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="96"/>
-                                                            <TextBox x:Name="PropertiesEntryHex4ByteB" HorizontalAlignment="Left" Margin="149,146,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="96"/>
-                                                            <TextBox x:Name="PropertiesEntryHex4ByteL" HorizontalAlignment="Left" Margin="149,88,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="96"/>
-                                                            <Label Content="Lil Endian 00 right &#xA;Ex: 1400  2B00&#xA;Big Endian 00 left&#xA;Ex: 0014  002B&#xD;&#xA;&#xA;Most consoles use&#xD;&#xA;big" Margin="243,0,0,0" Height="176" VerticalAlignment="Center" HorizontalAlignment="Left" Width="193"/>
+                                                            <TextBox x:Name="PropertiesEntry2ByteB" HorizontalAlignment="Left" Margin="34,58,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="111"/>
+                                                            <TextBox x:Name="PropertiesEntry2ByteL" HorizontalAlignment="Left" Margin="34,119,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="112"/>
+                                                            <TextBox x:Name="PropertiesEntry4ByteB" HorizontalAlignment="Left" Margin="34,88,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="111"/>
+                                                            <TextBox x:Name="PropertiesEntry4ByteL" HorizontalAlignment="Left" Margin="34,149,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="112"/>
+                                                            <TextBox x:Name="PropertiesEntryHex1Byte" HorizontalAlignment="Left" Margin="149,28,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="110"/>
+                                                            <TextBox x:Name="PropertiesEntryHex2ByteB" HorizontalAlignment="Left" Margin="149,58,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="110"/>
+                                                            <TextBox x:Name="PropertiesEntryHex2ByteL" HorizontalAlignment="Left" Margin="150,119,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="109"/>
+                                                            <TextBox x:Name="PropertiesEntryHex4ByteB" HorizontalAlignment="Left" Margin="149,88,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="110"/>
+                                                            <TextBox x:Name="PropertiesEntryHex4ByteL" HorizontalAlignment="Left" Margin="150,149,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="109"/>
+                                                            <TextBox x:Name="PropertiesEntry1ByteNegative" HorizontalAlignment="Left" Margin="264,28,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="122" Foreground="#FFFF8000"/>
+                                                            <TextBox x:Name="PropertiesEntry2ByteBNegative" HorizontalAlignment="Left" Margin="264,58,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="122" Foreground="#FFFF8000"/>
+                                                            <TextBox x:Name="PropertiesEntry2ByteLNegative" HorizontalAlignment="Left" Margin="264,119,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="122" Foreground="#FFFF8000"/>
+                                                            <TextBox x:Name="PropertiesEntry4ByteBNegative" HorizontalAlignment="Left" Margin="264,88,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="122" Foreground="#FFFF8000"/>
+                                                            <TextBox x:Name="PropertiesEntry4ByteLNegative" HorizontalAlignment="Left" Margin="264,149,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="122" Foreground="#FFFF8000"/>
 
                                                         </Grid>
                                                     </DockPanel>

--- a/Windows/Workshop.xaml.cs
+++ b/Windows/Workshop.xaml.cs
@@ -1948,6 +1948,11 @@ namespace GameEditorStudio
 
             EntryManager EntryManager = new();
             EntryManager.LoadEntry(this, EditorClass, EntryClass);
+
+            if (TheCrossReference != null)
+            {
+                TheCrossReference.FillLearnBox(EditorClass, EntryClass);
+            }
         }
 
         private void SetNumberboxSigned(object sender, RoutedEventArgs e)
@@ -1956,6 +1961,11 @@ namespace GameEditorStudio
 
             EntryManager EntryManager = new();
             EntryManager.LoadEntry(this, EditorClass, EntryClass);
+
+            if (TheCrossReference != null)
+            {
+                TheCrossReference.FillLearnBox(EditorClass, EntryClass);
+            }
         }
 
 
@@ -2563,6 +2573,14 @@ namespace GameEditorStudio
                     EntryClass.Symbology.ToolTip = "This entry is never zero.\n\nThis is actually pretty rare, so you should be suspicious. ";
 
                 }
+                else if (AllValues.All(v => v == 0 || v == 1 || v == 2) && AllValues.Contains(0) && AllValues.Contains(1) && AllValues.Contains(2)) //Is always 0/1/2
+                {
+                    //EntryClass.Symbology.Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString(HalfColor));
+                    EntryClass.Symbology.Foreground = Brushes.Gray;
+                    EntryClass.Symbology.Content = "012";
+                    EntryClass.Symbology.ToolTip = "This entry's value is always 0, 1, or 2.";
+
+                }
                 else if (IsMostlyX == true) //If Mostly X
                 {
                     //EntryClass.Symbology.Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString(HalfColor));
@@ -2576,7 +2594,15 @@ namespace GameEditorStudio
                     EntryClass.Symbology.Foreground = Brushes.Gray;
                     EntryClass.Symbology.Content = "X??";
                     EntryClass.Symbology.ToolTip = "This entry's value is the same somewhere between 50% and 80% of the time.";
-                    EntryClass.Symbology.FontSize = 12;
+                    EntryClass.Symbology.FontSize = 20;
+
+                }
+                else //If Mostly X
+                {
+                    //EntryClass.Symbology.Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString(HalfColor));
+                    EntryClass.Symbology.Foreground = Brushes.Gray; 
+                    EntryClass.Symbology.Content = "" + uniqueCount;
+                    EntryClass.Symbology.ToolTip = "This entry has " + uniqueCount + " unique values.";
 
                 }
 


### PR DESCRIPTION
NEW:
- The entry cross reference panel now updates whenever a value changes, and when you change a entry to allow negative values. 
- The entry hex panel now shows possible negative values. (Big vs Little explanation moved to tooltip)
- Symbology has a new 012 symbol for when an entry's values are always 0/1/2.
- Symbology ALWAYS gives a symbol now, all the way down to saying a entry only has 3 possible values. 


FIXES:
- The hex info for 1 byte decimal now actually is that, instead of the entry's current value. 
- The hex info HEX boxes no longer overflow (They are now 30% wider).
- Symbology symbol x?? is now a normal font size. 