### PR TITLE
Recode to fix new rows appearing in wrong editor.

### DIFF
--- a/Databases/StandardEditorData.cs
+++ b/Databases/StandardEditorData.cs
@@ -135,7 +135,7 @@ namespace GameEditorStudio
     public class Column
     {
         public string ColumnName { get; set; } = "New Column"; //XML The name of a column.
-        public DockPanel? ColumnPanel { get; set; }
+        public DockPanel ColumnPanel { get; set; } = new();
         public List<ItemBase> ItemBaseList { get; set; } = new();
         public Label ColumnLabel { get; set; }
         public Category ColumnRow { get; set; }

--- a/Editors/MakeButton.cs
+++ b/Editors/MakeButton.cs
@@ -141,7 +141,7 @@ namespace GameEditorStudio
                 TheWorkshop.HIDEALL();
                 TheEditorClass.EditorBackPanel.Visibility = Visibility.Visible;
 
-                LibraryMan.GotoGeneralEditor(TheWorkshop);
+                LibraryMan.GotoRightBarGeneralTab(TheWorkshop);
 
                 TheWorkshop.PropertiesTextboxEditorName.Text = TheEditorNameLabel.Content.ToString();
 
@@ -276,7 +276,14 @@ namespace GameEditorStudio
 
 
                 TheWorkshop.EditorClass = TheEditorClass; //this used to be EditorClass = TheEditorClass; and i changed it because i might have meant this, but also maybe not and i made a new bug?
-
+                TheWorkshop.EntryClass = TheEditorClass.StandardEditorData.SelectedEntry; //This is the entry that is currently selected in the editor.
+                TheWorkshop.ColumnClass = TheWorkshop.EntryClass.EntryColumn;
+                TheWorkshop.CategoryClass = TheWorkshop.ColumnClass.ColumnRow; //This is the category that is currently selected in the editor.
+                if (TheWorkshop.EntryClass.EntryGroup != null) 
+                {
+                    TheWorkshop.GroupClass = TheWorkshop.EntryClass.EntryGroup; //This is the group that is currently selected in the editor.
+                }
+                
 
 
 

--- a/Editors/Standard/LoadStandardEditor.cs
+++ b/Editors/Standard/LoadStandardEditor.cs
@@ -144,6 +144,10 @@ namespace GameEditorStudio
                 //There exist some more as well, but those aren't strictly necessary to a new entry.
 
                 Entry EntryClass = new();
+                EntryClass.EntryColumn = ColumnClass; //This is the column this entry belongs to.
+                EntryClass.EntryRow = RowClass; //This is the row this entry belongs to.
+                EntryClass.EntryEditor = EditorClass; //This is the editor this entry belongs to.
+
                 ColumnClass.ItemBaseList.Add(EntryClass);
                 EditorClass.StandardEditorData.MasterEntryList.Add(EntryClass); 
 
@@ -344,9 +348,23 @@ namespace GameEditorStudio
                     void LoadEntry(XElement Xentry, Group MyGroup) 
                     {
                         Entry EntryClass = new();
+                        EntryClass.EntryColumn = ColumnClass; //This is the column this entry belongs to.
+                        EntryClass.EntryRow = CategoryClass; //This is the row this entry belongs to.
+                        EntryClass.EntryEditor = EditorClass; //This is the editor this entry belongs to.
+                        if (MyGroup != null)
+                        {
+                            EntryClass.EntryGroup = MyGroup; 
+                        }
+
                         EditorClass.StandardEditorData.MasterEntryList.Add(EntryClass);
-                        if (MyGroup != null) { MyGroup.EntryList.Add(EntryClass); } //Group adding.
-                        if (MyGroup == null) { ColumnClass.ItemBaseList.Add(EntryClass); } //Column adding.
+                        if (MyGroup != null) 
+                        {
+                            MyGroup.EntryList.Add(EntryClass); 
+                        } 
+                        if (MyGroup == null)
+                        {
+                            ColumnClass.ItemBaseList.Add(EntryClass);
+                        } //Column adding.
                         
 
                         EntryClass.Name = Xentry.Element("Name")?.Value;

--- a/Editors/Standard/StandardEditorMethods.cs
+++ b/Editors/Standard/StandardEditorMethods.cs
@@ -17,18 +17,18 @@ namespace GameEditorStudio
     {
                 
 
-        public static void MoveGroupToBottomOfColumn(Group Group, Column column) 
+        public static void MoveGroupToBottomOfColumn(Group Group, Column ToColumn) 
         {
             Column BeforeColumn = Group.GroupColumn; //Save the column before we change it, so we can delete it later if needed.
-            Column AfterColumn = column; //Save the column after we change it, so we can delete it later if needed.
+            Column AfterColumn = ToColumn; //Save the column after we change it, so we can delete it later if needed.
 
             Group.GroupColumn.ItemBaseList.Remove(Group);
             Group.GroupColumn.ColumnPanel.Children.Remove(Group.GroupBorder);
 
-            column.ColumnPanel.Children.Add(Group.GroupBorder);
-            column.ItemBaseList.Add(Group);
+            ToColumn.ColumnPanel.Children.Add(Group.GroupBorder);
+            ToColumn.ItemBaseList.Add(Group);
 
-            Group.GroupColumn = column;
+            Group.GroupColumn = ToColumn;
             foreach (Entry entry in Group.EntryList)
             {
                 entry.EntryColumn = Group.GroupColumn; //Update the entry's column to the new group column.
@@ -252,14 +252,14 @@ namespace GameEditorStudio
             LabelWidth(AfterColumn);
         }
 
-        public static void EntryActivate(Workshop TheWorkshop, Entry EntryClass) 
+        public static void EntryActivate(Entry EntryClass) 
         {
-            //if (TheWorkshop.IsPreviewMode == true) { return; }
-            Editor EditorClass = EntryClass.EntryEditor;
+            //if (TheWorkshop.IsPreviewMode == true) { return; }            
+            Workshop TheWorkshop = EntryClass.EntryEditor.Workshop;
 
             EntryManager EntryData = new();
             EntryData.EntryBecomeActive(EntryClass);
-            EntryData.UpdateEntryProperties(TheWorkshop, EditorClass);
+            EntryData.UpdateEntryProperties(EntryClass);
 
             //EditorClass.SWData.EditorTopBar.EntryNoteBox.Text = EntryClass.EntryTooltip;
             TheWorkshop.EntryNoteTextbox.Text = EntryClass.WorkshopTooltip;

--- a/Main/EntryManager.cs
+++ b/Main/EntryManager.cs
@@ -514,7 +514,7 @@ namespace GameEditorStudio
             NumberBox.PreviewMouseDown += (sender, e) =>
             {
                 EntryBecomeActive(EntryClass);
-                UpdateEntryProperties(TheWorkshop, EntryClass.EntryEditor);
+                UpdateEntryProperties(EntryClass);
             };
             NumberBox.PreviewTextInput += (sender, e) =>
             {
@@ -596,7 +596,7 @@ namespace GameEditorStudio
                         if (EntryClass == EntryClass.EntryEditor.StandardEditorData.SelectedEntry)
                         {
                             SaveEntry(EntryClass.EntryEditor, EntryClass);
-                            UpdateEntryProperties(TheWorkshop, EntryClass.EntryEditor);
+                            UpdateEntryProperties(EntryClass);
                         }
                     }
                 }
@@ -653,7 +653,7 @@ namespace GameEditorStudio
                 }
 
                 EntryBecomeActive(EntryClass);
-                UpdateEntryProperties(TheWorkshop, EntryClass.EntryEditor);
+                UpdateEntryProperties(EntryClass);
 
             };
             EntryClass.EntryTypeCheckBox.CheckBoxButton = CheckBox;
@@ -719,7 +719,7 @@ namespace GameEditorStudio
                 }
 
                 EntryBecomeActive(EntryClass);
-                UpdateEntryProperties(TheWorkshop, EntryClass.EntryEditor);
+                UpdateEntryProperties(EntryClass);
 
             };
             ////////////////////////////////////////////////
@@ -758,7 +758,7 @@ namespace GameEditorStudio
                     SaveEntry(EntryClass.EntryEditor, EntryClass);
                 }
                 EntryBecomeActive(EntryClass);
-                UpdateEntryProperties(TheWorkshop, EntryClass.EntryEditor);
+                UpdateEntryProperties(EntryClass);
 
             };
             ////////////////////////////////////////////////
@@ -797,7 +797,7 @@ namespace GameEditorStudio
                     SaveEntry(EntryClass.EntryEditor, EntryClass);
                 }
                 EntryBecomeActive(EntryClass);
-                UpdateEntryProperties(TheWorkshop, EntryClass.EntryEditor);
+                UpdateEntryProperties(EntryClass);
 
             };
             ////////////////////////////////////////////////
@@ -836,7 +836,7 @@ namespace GameEditorStudio
                     SaveEntry(EntryClass.EntryEditor, EntryClass);
                 }
                 EntryBecomeActive(EntryClass);
-                UpdateEntryProperties(TheWorkshop, EntryClass.EntryEditor);
+                UpdateEntryProperties(EntryClass);
 
             };
             ////////////////////////////////////////////////
@@ -875,7 +875,7 @@ namespace GameEditorStudio
                     SaveEntry(EntryClass.EntryEditor, EntryClass);
                 }
                 EntryBecomeActive(EntryClass);
-                UpdateEntryProperties(TheWorkshop, EntryClass.EntryEditor);
+                UpdateEntryProperties(EntryClass);
 
             };
             ////////////////////////////////////////////////
@@ -914,7 +914,7 @@ namespace GameEditorStudio
                     SaveEntry(EntryClass.EntryEditor, EntryClass);
                 }
                 EntryBecomeActive(EntryClass);
-                UpdateEntryProperties(TheWorkshop, EntryClass.EntryEditor);
+                UpdateEntryProperties(EntryClass);
 
             };
             ////////////////////////////////////////////////
@@ -953,7 +953,7 @@ namespace GameEditorStudio
                     SaveEntry(EntryClass.EntryEditor, EntryClass);
                 }
                 EntryBecomeActive(EntryClass);
-                UpdateEntryProperties(TheWorkshop, EntryClass.EntryEditor);
+                UpdateEntryProperties(EntryClass);
 
             };
             ////////////////////////////////////////////////
@@ -992,7 +992,7 @@ namespace GameEditorStudio
                     SaveEntry(EntryClass.EntryEditor, EntryClass);
                 }
                 EntryBecomeActive(EntryClass);
-                UpdateEntryProperties(TheWorkshop, EntryClass.EntryEditor);
+                UpdateEntryProperties(EntryClass);
             };
             ////////////////////////////////////////////////
 
@@ -1196,7 +1196,7 @@ namespace GameEditorStudio
 
                 TheWorkshop.EntryClass = EntryClass;
                 EntryBecomeActive(EntryClass);
-                UpdateEntryProperties(TheWorkshop, EntryClass.EntryEditor);
+                UpdateEntryProperties(EntryClass);
 
                 TheWorkshop.EntryListBox.SelectionChanged -= TheWorkshop.EntryListBox_SelectionChanged; // Remove event handler    
                 TheWorkshop.EntryListBox.Items.Clear(); // Clear items
@@ -1545,7 +1545,7 @@ namespace GameEditorStudio
                 EntryClass.EntryByteDecimal = number;
 
                 SaveEntry(EntryClass.EntryEditor, EntryClass);
-                UpdateEntryProperties(Workshop, EntryClass.EntryEditor);
+                UpdateEntryProperties(EntryClass);
             };
 
 
@@ -1744,14 +1744,16 @@ namespace GameEditorStudio
         }
 
 
-        public void UpdateEntryProperties(Workshop TheWorkshop ,Editor EditorClass) 
+        public void UpdateEntryProperties(Entry EntryClass) 
         {
             //This used to happen on tree view selection change, but it caused a shit ton of lag. Now it doesn't. if my program starts lagging again, consider if this is responsible! >:(
 
-            
+            Workshop TheWorkshop = EntryClass.EntryEditor.Workshop;
+            Editor EditorClass = EntryClass.EntryEditor;
+
+
             LibraryMan.GotoGeneralEntry(TheWorkshop);
 
-            Entry EntryClass = EditorClass.StandardEditorData.SelectedEntry;
             //////////////////////////////////////Workship Update//////////////////////////////////////////
             TheWorkshop.EditorClass = EntryClass.EntryEditor;
             TheWorkshop.CategoryClass = EntryClass.EntryRow;

--- a/Main/LibraryMan.cs
+++ b/Main/LibraryMan.cs
@@ -33,6 +33,8 @@ namespace GameEditorStudio
         public static bool ShowHiddenEntrys { get; set; } = false;
         public static bool ShowSymbology { get; set; } = false;
         public static bool ShowTranslationPanel { get; set; } = false;
+
+        public static bool DebugShowALL { get; set; } = false;
         //END
 
         public static string ApplicationLocation { get; set; } = "";
@@ -372,7 +374,7 @@ namespace GameEditorStudio
             var generalRowTab = TheWorkshop.TabTest.Visibility = Visibility.Hidden;
         }
 
-        public static void GotoGeneralEditor(Workshop TheWorkshop) 
+        public static void GotoRightBarGeneralTab(Workshop TheWorkshop) 
         {
             var GeneralTabControl = TheWorkshop.TabTest.Visibility = Visibility.Visible;
 

--- a/Windows/Workshop.xaml
+++ b/Windows/Workshop.xaml
@@ -82,6 +82,8 @@
                 <TextBox DockPanel.Dock="Left" x:Name="EntryAddressOffsetTextbox" Text="0" Width="35" Margin="2,1,2,1" KeyDown="EntryOffsetTextboxKeyDown" ToolTip="This textbox value (after pressing enter) will make each entry-ID APPEAR as if it's offset ID was +/- X number. Such as -3 or +5. &#xD;&#xA;It does not actually change the offset of any entrys, only the appearence." />
                 <Button Content="👁"  DockPanel.Dock="Left" x:Name="EntryHiddenToggle"   Click="ToggleHiddenEntrys" Margin="2,0,2,0" ToolTip="Toggles the visibility of hidden entrys. &#xD;&#xA;When visable, a hidden entry will appear red. &#xD;&#xA;Note that any entrys that represent text are forced to hidden when the workshop opens, even if you set them not to be." Width="38"/>
 
+                <Button Content="👁️‍🗨️"  DockPanel.Dock="Left" x:Name="DebugShowALL"   Click="ToggleDebugShowALL" Margin="2,0,2,0" ToolTip="Makes EVERYTHING visable. &#xD;&#xA;This button only exists in debug mode." Width="38"/>
+
 
 
 
@@ -426,7 +428,7 @@
                                                                 <ComboBoxItem Content="4 Bytes Little Endian"/>
                                                                 <ComboBoxItem Content="2 Bytes Big Endian"/>
                                                                 <ComboBoxItem Content="4 Bytes Big Endian"/>
-                                                                
+
                                                             </ComboBox>
 
                                                             <Label Content="Entry Type" Grid.Row="5" Grid.Column="1" Margin="0"/>
@@ -530,25 +532,25 @@
                                                             <Label Content="D Negatives" HorizontalAlignment="Left" Margin="259,-2,0,0" VerticalAlignment="Top"/>
 
                                                             <Label Content="1" HorizontalAlignment="Left" Margin="4,24,0,0" VerticalAlignment="Top"/>
-                                                            <Label Content="2B" HorizontalAlignment="Left" Margin="4,56,0,0" VerticalAlignment="Top"/>
-                                                            <Label Content="2L" HorizontalAlignment="Left" Margin="4,115,0,0" VerticalAlignment="Top"/>
-                                                            <Label Content="4B" HorizontalAlignment="Left" Margin="4,84,0,0" VerticalAlignment="Top"/>
-                                                            <Label Content="4L" HorizontalAlignment="Left" Margin="4,145,0,0" VerticalAlignment="Top"/>
+                                                            <Label Content="2B" HorizontalAlignment="Left" Margin="4,116,0,0" VerticalAlignment="Top"/>
+                                                            <Label Content="2L" HorizontalAlignment="Left" Margin="4,55,0,0" VerticalAlignment="Top"/>
+                                                            <Label Content="4B" HorizontalAlignment="Left" Margin="4,144,0,0" VerticalAlignment="Top"/>
+                                                            <Label Content="4L" HorizontalAlignment="Left" Margin="4,85,0,0" VerticalAlignment="Top"/>
                                                             <TextBox x:Name="PropertiesEntry1Byte" HorizontalAlignment="Left" Margin="34,28,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="111"/>
-                                                            <TextBox x:Name="PropertiesEntry2ByteB" HorizontalAlignment="Left" Margin="34,58,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="111"/>
-                                                            <TextBox x:Name="PropertiesEntry2ByteL" HorizontalAlignment="Left" Margin="34,119,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="112"/>
-                                                            <TextBox x:Name="PropertiesEntry4ByteB" HorizontalAlignment="Left" Margin="34,88,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="111"/>
-                                                            <TextBox x:Name="PropertiesEntry4ByteL" HorizontalAlignment="Left" Margin="34,149,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="112"/>
+                                                            <TextBox x:Name="PropertiesEntry2ByteB" HorizontalAlignment="Left" Margin="34,118,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="112"/>
+                                                            <TextBox x:Name="PropertiesEntry2ByteL" HorizontalAlignment="Left" Margin="34,59,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="112"/>
+                                                            <TextBox x:Name="PropertiesEntry4ByteB" HorizontalAlignment="Left" Margin="34,148,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="112"/>
+                                                            <TextBox x:Name="PropertiesEntry4ByteL" HorizontalAlignment="Left" Margin="34,89,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="112"/>
                                                             <TextBox x:Name="PropertiesEntryHex1Byte" HorizontalAlignment="Left" Margin="149,28,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="110"/>
-                                                            <TextBox x:Name="PropertiesEntryHex2ByteB" HorizontalAlignment="Left" Margin="149,58,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="110"/>
-                                                            <TextBox x:Name="PropertiesEntryHex2ByteL" HorizontalAlignment="Left" Margin="150,119,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="109"/>
-                                                            <TextBox x:Name="PropertiesEntryHex4ByteB" HorizontalAlignment="Left" Margin="149,88,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="110"/>
-                                                            <TextBox x:Name="PropertiesEntryHex4ByteL" HorizontalAlignment="Left" Margin="150,149,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="109"/>
+                                                            <TextBox x:Name="PropertiesEntryHex2ByteB" HorizontalAlignment="Left" Margin="150,118,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="109"/>
+                                                            <TextBox x:Name="PropertiesEntryHex2ByteL" HorizontalAlignment="Left" Margin="150,59,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="109"/>
+                                                            <TextBox x:Name="PropertiesEntryHex4ByteB" HorizontalAlignment="Left" Margin="150,148,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="109"/>
+                                                            <TextBox x:Name="PropertiesEntryHex4ByteL" HorizontalAlignment="Left" Margin="150,89,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="109"/>
                                                             <TextBox x:Name="PropertiesEntry1ByteNegative" HorizontalAlignment="Left" Margin="264,28,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="122" Foreground="#FFFF8000"/>
-                                                            <TextBox x:Name="PropertiesEntry2ByteBNegative" HorizontalAlignment="Left" Margin="264,58,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="122" Foreground="#FFFF8000"/>
-                                                            <TextBox x:Name="PropertiesEntry2ByteLNegative" HorizontalAlignment="Left" Margin="264,119,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="122" Foreground="#FFFF8000"/>
-                                                            <TextBox x:Name="PropertiesEntry4ByteBNegative" HorizontalAlignment="Left" Margin="264,88,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="122" Foreground="#FFFF8000"/>
-                                                            <TextBox x:Name="PropertiesEntry4ByteLNegative" HorizontalAlignment="Left" Margin="264,149,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="122" Foreground="#FFFF8000"/>
+                                                            <TextBox x:Name="PropertiesEntry2ByteBNegative" HorizontalAlignment="Left" Margin="264,118,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="122" Foreground="#FFFF8000"/>
+                                                            <TextBox x:Name="PropertiesEntry2ByteLNegative" HorizontalAlignment="Left" Margin="264,59,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="122" Foreground="#FFFF8000"/>
+                                                            <TextBox x:Name="PropertiesEntry4ByteBNegative" HorizontalAlignment="Left" Margin="264,148,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="122" Foreground="#FFFF8000"/>
+                                                            <TextBox x:Name="PropertiesEntry4ByteLNegative" HorizontalAlignment="Left" Margin="264,89,0,0" TextWrapping="Wrap" Text="TextBox" VerticalAlignment="Top" Width="122" Foreground="#FFFF8000"/>
 
                                                         </Grid>
                                                     </DockPanel>

--- a/Windows/Workshop.xaml.cs
+++ b/Windows/Workshop.xaml.cs
@@ -99,7 +99,12 @@ namespace GameEditorStudio
             ProjectDataItem = Project;  
 
             MyDatabase.Workshop = this;
-            
+
+            #if DEBUG
+
+            #else
+            DebugShowALL.Visibility = Visibility.Collapsed; //DebugShowALL is only visible in debug mode.
+            #endif
 
             foreach (Command command in TrueDatabase.Commands)
             {
@@ -334,7 +339,7 @@ namespace GameEditorStudio
 
         private void ToggleTranslationPanel(object sender, RoutedEventArgs e)
         {   
-            #if DEBUG
+#if DEBUG
             if (LibraryMan.ShowTranslationPanel == true)
             {
                 LibraryMan.ShowTranslationPanel = false;
@@ -343,7 +348,7 @@ namespace GameEditorStudio
             {
                 LibraryMan.ShowTranslationPanel = true;
             }               
-            #endif
+#endif
             
             UpdateLeftBars();
         }
@@ -433,7 +438,24 @@ namespace GameEditorStudio
                 "Just be aware the workshop owner probably intends some of the entrys to be hidden. Sorry~"); }
         }
 
-        
+        private void ToggleDebugShowALL(object sender, RoutedEventArgs e)
+        {
+            if (LibraryMan.DebugShowALL == true)
+            {
+                LibraryMan.DebugShowALL = false;
+                DebugShowALL.Foreground = Brushes.Gray;
+            }
+            else if (LibraryMan.DebugShowALL == false)
+            {
+                LibraryMan.DebugShowALL = true;
+                DebugShowALL.Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#1E70EC"));
+            }
+            UpdateEntryDecorations();
+
+            
+        }
+
+
 
         public void UpdateEntryDecorations() 
         {
@@ -443,8 +465,8 @@ namespace GameEditorStudio
 
                 foreach (var row in editor.StandardEditorData.CategoryList)
                 {
-                    //row.CategoryDockPanel.Visibility = Visibility.Collapsed;
-                    row.CatBorder.Visibility = Visibility.Collapsed;
+                    if (row.ColumnList.Count != 0) if( row.ColumnList[0].ItemBaseList.Count != 0) { row.CatBorder.Visibility = Visibility.Collapsed; }
+                    
 
                     foreach (var column in row.ColumnList)
                     {
@@ -459,7 +481,9 @@ namespace GameEditorStudio
                         {
                             column.ColumnPanel.Visibility = Visibility.Visible;
                         }
-                    }                    
+                    }
+
+                    
                 }
 
                 foreach (Entry entry in editor.StandardEditorData.MasterEntryList)
@@ -539,6 +563,40 @@ namespace GameEditorStudio
 
 
                 
+            }
+
+            if (LibraryMan.DebugShowALL == true) 
+            {
+                DEBUGSHOWALL();
+            }
+            
+        }
+
+        public void DEBUGSHOWALL() 
+        {
+            foreach (var editor in MyDatabase.GameEditors.Values) 
+            {
+                if (editor.EditorType != "DataTable") { continue; }
+
+                foreach (var row in editor.StandardEditorData.CategoryList) 
+                {
+                    row.CatBorder.Visibility = Visibility.Visible;
+
+                    foreach (var column in row.ColumnList)
+                    {
+                        column.ColumnPanel.Visibility = Visibility.Visible;
+
+                        foreach (Group group in column.ItemBaseList.OfType<Group>())
+                        {
+                            group.GroupPanel.Visibility = Visibility.Visible;
+                        }
+                    }
+                }
+
+                foreach (Entry entry in editor.StandardEditorData.MasterEntryList) 
+                {
+                    entry.EntryBorder.Visibility = Visibility.Visible;
+                }
             }
         }
 
@@ -1280,7 +1338,6 @@ namespace GameEditorStudio
         public void CreateNewRowAbove(Category TheCat)
         {
             Category NewRow = new();
-            NewRow.ColumnList = new List<Column>();
             NewRow.SWData = TheCat.SWData;
 
             int TheIndex = TheCat.SWData.CategoryList.IndexOf(TheCat);
@@ -1288,13 +1345,13 @@ namespace GameEditorStudio
 
 
             GenerateStandardEditor CreateSWEditorCode = new();
-            CreateSWEditorCode.CreateCategory(EditorClass.StandardEditorData, NewRow, this, MyDatabase, TheIndex);
+            CreateSWEditorCode.CreateCategory(NewRow);
 
 
             Column ColumnClass = new();
             NewRow.ColumnList.Add(ColumnClass);
             ColumnClass.ColumnRow = NewRow;
-            CreateSWEditorCode.CreateColumn(NewRow, ColumnClass, this, MyDatabase, -1);
+            CreateSWEditorCode.CreateColumn(ColumnClass);
 
         }
 
@@ -1302,7 +1359,6 @@ namespace GameEditorStudio
         public void CreateNewRowBelow(Category TheCat)
         {
             Category NewRow = new();
-            NewRow.ColumnList = new List<Column>();
             NewRow.SWData = TheCat.SWData;
 
             int TheIndex = TheCat.SWData.CategoryList.IndexOf(TheCat) + 1;
@@ -1310,13 +1366,13 @@ namespace GameEditorStudio
 
 
             GenerateStandardEditor CreateSWEditorCode = new();
-            CreateSWEditorCode.CreateCategory(EditorClass.StandardEditorData, NewRow, this, MyDatabase, TheIndex);
+            CreateSWEditorCode.CreateCategory(NewRow);
 
 
             Column ColumnClass = new();
             NewRow.ColumnList.Add(ColumnClass);
             ColumnClass.ColumnRow = NewRow;
-            CreateSWEditorCode.CreateColumn(NewRow, ColumnClass, this, MyDatabase, -1);
+            CreateSWEditorCode.CreateColumn(ColumnClass);
 
         }
 
@@ -1361,7 +1417,7 @@ namespace GameEditorStudio
             {
                 TheCat.SWData.MainDockPanel.Children.Remove(TheCat.CatBorder);
                 TheCat.SWData.CategoryList.Remove(TheCat);
-                LibraryMan.GotoGeneralEditor(this);
+                LibraryMan.GotoRightBarGeneralTab(this);
             }
             
             //Add a IF: count all entrys in all columns in this row, and do IF that is 0.
@@ -1419,7 +1475,7 @@ namespace GameEditorStudio
 
 
             GenerateStandardEditor CreateSWEditorCode = new();
-            CreateSWEditorCode.CreateColumn(Column.ColumnRow, Column, this, MyDatabase, TheIndex);
+            CreateSWEditorCode.CreateColumn(Column);
 
         }
 
@@ -1433,7 +1489,7 @@ namespace GameEditorStudio
 
 
             GenerateStandardEditor CreateSWEditorCode = new();
-            CreateSWEditorCode.CreateColumn(Column.ColumnRow, Column, this, MyDatabase, TheIndex);
+            CreateSWEditorCode.CreateColumn(Column);
 
         }
 
@@ -1625,7 +1681,7 @@ namespace GameEditorStudio
 
             EntryManager EManager = new();
             EManager.EntryBecomeActive(EntryClass);
-            EManager.UpdateEntryProperties(this, EditorClass);
+            EManager.UpdateEntryProperties(EditorClass.StandardEditorData.SelectedEntry);
         }
 
 
@@ -1762,6 +1818,8 @@ namespace GameEditorStudio
                 if (PropertiesEntryByteSizeComboBox.Text == "2 Bytes Big Endian") { NewSize = 2; NewSizeS = "2B"; }
                 if (PropertiesEntryByteSizeComboBox.Text == "4 Bytes Big Endian") { NewSize = 4; NewSizeS = "4B"; }
 
+                List<Entry> targets = new();
+
                 if (EntryClass.RowOffset <= EditorClass.StandardEditorData.DataTableRowSize - NewSize) //Cancel method IF: New size would overflow off the end of GameTableSize
                 {
 
@@ -1812,7 +1870,7 @@ namespace GameEditorStudio
                     //Below is what happens to OTHER ENTRYS, NOT the main entry having it's size changed.
 
 
-                    List<Entry> targets = new();
+                    
 
 
                     List<int> list = new();
@@ -1843,10 +1901,40 @@ namespace GameEditorStudio
                     }
 
                     //This makes sure when a entry is hidden / merged, that it is relocated to wherever the primary entry is.
+                    
+
+                    ////if Old bigger then new
+                    if (OldSize > NewSize)
+                    {
+                        foreach (int i in Enumerable.Range(Math.Min(OldSize, NewSize), Math.Abs(OldSize - NewSize))) //.OrderByDescending(x => x)
+                        {
+                            list.Add(EntryClass.RowOffset + i);
+                        }
+                        foreach (var num in list)
+                        {
+                            foreach (Entry entry in EditorClass.StandardEditorData.MasterEntryList)
+                            {
+                                if (entry.RowOffset == num) //Search for entry with offset+1 over current entry.  Offset+X
+                                {
+                                    entry.Endianness = "1";
+                                    entry.Bytes = 1;
+                                    MyDatabase.EntryManager.LoadEntry(this, EditorClass, entry);
+                                    //EntryData.ReloadEntry(Database, EditorClass, entry);
+                                    entry.EntryBorder.Visibility = Visibility.Visible;
+
+                                    targets.Add(entry);
+
+                                }
+                            }
+                            
+                        }
+                    }
+
+
                     foreach (var entry in targets)
                     {
-                                                
-                        if (entry.EntryGroup == null) 
+
+                        if (entry.EntryGroup == null)
                         {
                             entry.EntryColumn.ItemBaseList.Remove(entry);
                             entry.EntryColumn.ColumnPanel.Children.Remove(entry.EntryBorder);
@@ -1873,40 +1961,15 @@ namespace GameEditorStudio
                             EntryClass.EntryGroup.GroupPanel.Children.Insert(EntryLocation + Diffrence + 1, entry.EntryBorder);
                         }
 
-                        
+
 
 
                         entry.EntryRow = EntryClass.EntryRow;  //  PageClass.RowList[rowIndex + 1];
                         entry.EntryColumn = EntryClass.EntryColumn;   //PageClass.RowList[rowIndex + 1].ColumnList[0];
 
-                        if (EntryClass.EntryGroup != null) 
+                        if (EntryClass.EntryGroup != null)
                         {
-                            entry.EntryGroup = EntryClass.EntryGroup; 
-                        }
-                    }
-
-                    ////if Old bigger then new
-                    if (OldSize > NewSize)
-                    {
-                        foreach (int i in Enumerable.Range(Math.Min(OldSize, NewSize), Math.Abs(OldSize - NewSize))) //.OrderByDescending(x => x)
-                        {
-                            list.Add(EntryClass.RowOffset + i);
-                        }
-                        foreach (var num in list)
-                        {
-                            foreach (Entry entry in EditorClass.StandardEditorData.MasterEntryList)
-                            {
-                                if (entry.RowOffset == num) //Search for entry with offset+1 over current entry.  Offset+X
-                                {
-                                    entry.Endianness = "1";
-                                    entry.Bytes = 1;
-                                    MyDatabase.EntryManager.LoadEntry(this, EditorClass, entry);
-                                    //EntryData.ReloadEntry(Database, EditorClass, entry);
-                                    entry.EntryBorder.Visibility = Visibility.Visible;
-
-                                }
-                            }
-                            
+                            entry.EntryGroup = EntryClass.EntryGroup;
                         }
                     }
 
@@ -1934,6 +1997,7 @@ namespace GameEditorStudio
             }//End of IF
 
             UpdateSymbology(EntryClass);
+            UpdateEntryDecorations();
             
         }
 
@@ -2244,7 +2308,7 @@ namespace GameEditorStudio
 
 
             MyDatabase.EntryManager.SaveEntry(EntryClass.EntryEditor, EntryClass);
-            MyDatabase.EntryManager.UpdateEntryProperties(this, EntryClass.EntryEditor);
+            MyDatabase.EntryManager.UpdateEntryProperties(EditorClass.StandardEditorData.SelectedEntry);
 
 
             foreach (TabItem tabItem in MainTabControl.Items)


### PR DESCRIPTION
- Groups right click menu now has move left as it's first option instead of move right. This way its the same as google sheets.

- Empty Row Deletion is now only called when moving something.

- Swapped endianesse order back to Lil -> Big. As its what 010 does.

- New DebugHiddenToggle button.

- Splitting an entry now immedietly moves it's related entrys to under it.

- Recoded a ton of references to TheWorkshop. X classes. 